### PR TITLE
Service Manager: support service dependencies

### DIFF
--- a/src/OVN.Abstractions/IServiceManager.cs
+++ b/src/OVN.Abstractions/IServiceManager.cs
@@ -7,7 +7,7 @@ public interface IServiceManager
 {
     EitherAsync<Error, bool> ServiceExists();
     EitherAsync<Error, string> GetServiceCommand();
-    EitherAsync<Error, Unit> CreateService(string displayName, string command, CancellationToken cancellationToken);
+    EitherAsync<Error, Unit> CreateService(string displayName, string command, Seq<string> dependencies, CancellationToken cancellationToken);
     EitherAsync<Error, Unit> RemoveService(CancellationToken cancellationToken);
     EitherAsync<Error, Unit> EnsureServiceStarted(CancellationToken cancellationToken);
     EitherAsync<Error, Unit> EnsureServiceStopped(CancellationToken cancellationToken);

--- a/src/OVN.Core/WindowsServiceManager.cs
+++ b/src/OVN.Core/WindowsServiceManager.cs
@@ -47,7 +47,11 @@ internal class WindowsServiceManager : IServiceManager
             .ToEitherAsync().Flatten();
     }
 
-    public EitherAsync<Error, Unit> CreateService(string displayName, string command, CancellationToken cancellationToken)
+    public EitherAsync<Error, Unit> CreateService(
+        string displayName,
+        string command,
+        Seq<string> dependencies,
+        CancellationToken cancellationToken)
     {
         return Prelude.TryAsync<Either<Error, Unit>>(async () =>
             {
@@ -56,6 +60,8 @@ internal class WindowsServiceManager : IServiceManager
                 sb.Append((string?)$"binPath=\"{command.Replace("\"", "\\\"")}\" ");
                 sb.Append((string?)$"DisplayName=\"{displayName}\" ");
                 sb.Append($"start=auto ");
+                if(!dependencies.IsEmpty)
+                    sb.Append($"depend=\"{ string.Join("/", dependencies) }\" ");
 
                 var scProcess = _sysEnv.CreateProcess();
                 scProcess.StartInfo.FileName = "sc.exe";

--- a/src/OVNAgent/Program.cs
+++ b/src/OVNAgent/Program.cs
@@ -6,14 +6,15 @@ using Dbosoft.OVN;
 using Dbosoft.OVN.Nodes;
 using Dbosoft.OVN.OSCommands.OVN;
 using Dbosoft.OVNAgent;
+using LanguageExt;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using YamlDotNet.Serialization;
 
 
-var logLevelOptions = new Option<LogLevel>("--logLevel", () => LogLevel.Information);
-var nodeTypeOptions = new Option<NodeType>("--nodes", () => NodeType.AllInOne );
+var logLevelOptions = new System.CommandLine.Option<LogLevel>("--logLevel", () => LogLevel.Information);
+var nodeTypeOptions = new System.CommandLine.Option<NodeType>("--nodes", () => NodeType.AllInOne );
 
 var rootCommand = new RootCommand();
 rootCommand.AddGlobalOption(logLevelOptions);
@@ -27,7 +28,7 @@ var netplanCommand = new Command("netplan", "netplan commands");
 rootCommand.Add(netplanCommand);
 
 var applyCommand = new Command("apply", "apply network plan");
-var fileOption = new Option<FileInfo>("--file");
+var fileOption = new System.CommandLine.Option<FileInfo>("--file");
 applyCommand.AddOption(fileOption);
 applyCommand.SetHandler(ApplyNetplan, logLevelOptions, fileOption);
 netplanCommand.AddCommand(applyCommand);
@@ -143,7 +144,7 @@ static async Task ManageServiceCommand(bool install, LogLevel logLevel, NodeType
     if (install)
     {
         _ = await serviceManager.CreateService(
-                $"OVN {nodeType}", command, CancellationToken.None)
+                $"OVN {nodeType}", command, Prelude.Seq<string>(), CancellationToken.None)
             .Bind(_ => serviceManager.EnsureServiceStarted(CancellationToken.None))
             .IfLeft(l => l.Throw());
         return;

--- a/src/OVNAgent/Program.cs
+++ b/src/OVNAgent/Program.cs
@@ -144,7 +144,7 @@ static async Task ManageServiceCommand(bool install, LogLevel logLevel, NodeType
     if (install)
     {
         _ = await serviceManager.CreateService(
-                $"OVN {nodeType}", command, Prelude.Seq<string>(), CancellationToken.None)
+                $"OVN {nodeType}", command, Seq<string>.Empty, CancellationToken.None)
             .Bind(_ => serviceManager.EnsureServiceStarted(CancellationToken.None))
             .IfLeft(l => l.Throw());
         return;


### PR DESCRIPTION
Extend the `ServiceManager` to support the configuration of dependencies for Windows services.