### PR TITLE
added support for tags in external switch ports

### DIFF
--- a/src/OVN.Core/NetworkPlanConfigurationExtensions.cs
+++ b/src/OVN.Core/NetworkPlanConfigurationExtensions.cs
@@ -55,7 +55,7 @@ public static class NetworkPlanConfigurationExtensions
         };
     }
 
-    public static NetworkPlan AddExternalNetworkPort(this NetworkPlan plan, string switchName, string externalNetwork)
+    public static NetworkPlan AddExternalNetworkPort(this NetworkPlan plan, string switchName, string externalNetwork, int? tag)
     {
         var name = $"SN-{switchName}-{externalNetwork}";
         return plan with
@@ -67,7 +67,8 @@ public static class NetworkPlanConfigurationExtensions
                 Type = "localnet",
                 Options = new Dictionary<string, string> { { "network_name", externalNetwork } }.ToMap(),
                 Addresses = new[] { "unknown" }.ToSeq(),
-                ExternalIds = new Dictionary<string, string> { { "network_plan", plan.Id } }.ToMap()
+                ExternalIds = new Dictionary<string, string> { { "network_plan", plan.Id } }.ToMap(),
+                Tag = tag
             })
         };
     }

--- a/src/OVN.Core/OSCommands/OVSFieldActivator.cs
+++ b/src/OVN.Core/OSCommands/OVSFieldActivator.cs
@@ -150,8 +150,13 @@ internal static class OVSFieldActivator
                         break;
                     case JsonValueKind.Number:
                         var jsonDoubleValue = element.Deserialize<double>();
-                        objectValue = TypeDescriptor.GetConverter(typeof(T))
-                            .ConvertFrom(jsonDoubleValue);
+
+                        if(typeof(T) == typeof(int) || typeof(T) == typeof(long) || typeof(T) == typeof(byte))
+                            objectValue = TypeDescriptor.GetConverter(typeof(T))
+                                .ConvertFrom(jsonDoubleValue.ToString("F0"));
+                        else
+                            objectValue = TypeDescriptor.GetConverter(typeof(T))
+                                .ConvertFrom(jsonDoubleValue);
 
                         break;
                     case JsonValueKind.True:

--- a/src/OVN.Primitives/Model/OVN/LogicalSwitchPort.cs
+++ b/src/OVN.Primitives/Model/OVN/LogicalSwitchPort.cs
@@ -14,7 +14,9 @@ public record LogicalSwitchPort : OVSTableRecord, IHasParentReference, IOVSEntit
             { "addresses", OVSSet<string>.Metadata() },
             { "dhcpv4_options", OVSSet<Guid>.Metadata() },
             { "port_security", OVSSet<string>.Metadata() },
-            { "options", OVSMap<string>.Metadata(true) }
+            { "options", OVSMap<string>.Metadata(true) },
+            { "tag", OVSValue<int>.Metadata() }
+
         };
 
     public Seq<string> Addresses => GetSet<string>("addresses");

--- a/src/OVN.Primitives/Model/OVN/PlannedSwitchPort.cs
+++ b/src/OVN.Primitives/Model/OVN/PlannedSwitchPort.cs
@@ -14,7 +14,8 @@ public record PlannedSwitchPort(string SwitchName) : OVSEntity, IHasParentRefere
             { "dhcpv4_options", OVSSet<Guid>.Metadata() },
             { "port_security", OVSSet<string>.Metadata() },
             { "options", OVSMap<string>.Metadata() },
-            { "type", OVSValue<string>.Metadata() }
+            { "type", OVSValue<string>.Metadata() },
+            { "tag", OVSValue<int>.Metadata() }
         };
 
     public Seq<string> Addresses
@@ -56,5 +57,11 @@ public record PlannedSwitchPort(string SwitchName) : OVSEntity, IHasParentRefere
     {
         get => GetValue<string>("name");
         init => SetValue("name", value);
+    }
+
+    public int? Tag
+    {
+        get => GetValue<int>("tag");
+        init => SetValue("tag", value);
     }
 }

--- a/src/OVN.Primitives/Model/OVSEntity.cs
+++ b/src/OVN.Primitives/Model/OVSEntity.cs
@@ -47,14 +47,14 @@ public record OVSEntity
             : ((OVSReference)Values[propertyName]).Set;
     }
 
-    protected Map<string, T> GetMap<T>(string propertyName) where T : notnull
+    protected Map<string, T> GetMap<T>(string propertyName)
     {
         return !Values.ContainsKey(propertyName)
             ? default
             : ((OVSMap<T>)Values[propertyName]).Map;
     }
 
-    protected void SetValue<T>(string propertyName, T? value) where T : notnull
+    protected void SetValue<T>(string propertyName, T? value)
     {
         if (Values.ContainsKey(propertyName)) Values = Values.Remove(propertyName);
 

--- a/src/OVNAgent/NetworkPlanParser.cs
+++ b/src/OVNAgent/NetworkPlanParser.cs
@@ -292,8 +292,16 @@ public static class NetworkPlanParser
                 || portValues["network"] is not string networkName)
                 throw new InvalidDataException($"network name is required for network port (switch: {switchName})");
 
+            int? tag = null;
+
+            if (portValues.ContainsKey("tag")
+                && portValues["tag"] is int tagValue)
+            {
+                tag = tagValue;
+            }
+
             return networkPlan
-                .AddExternalNetworkPort(switchName, networkName);
+                .AddExternalNetworkPort(switchName, networkName, tag);
         }
         
         NetworkPlan ParseGenericPort(NetworkPlan networkPlan, 


### PR DESCRIPTION
Added column tag from logical_switch_port table and updated OVSField mapper to handle int fields (like tag) correctly.