### PR TITLE
Support more OVN routing features

### DIFF
--- a/src/OVN.Core/NetworkPlanConfigurationExtensions.cs
+++ b/src/OVN.Core/NetworkPlanConfigurationExtensions.cs
@@ -2,27 +2,34 @@ using System.Net;
 using Dbosoft.OVN.Model.OVN;
 using LanguageExt;
 
+using static LanguageExt.Prelude;
+
 namespace Dbosoft.OVN;
 
 public static class NetworkPlanConfigurationExtensions
 {
-
-    public static NetworkPlan AddSwitch(this NetworkPlan plan, string switchName, string[]? dnsRecordsNames = default)
+    public static NetworkPlan AddSwitch(
+        this NetworkPlan plan,
+        string switchName,
+        Seq<string> dnsRecordsNames = default)
     {
         return plan with
         {
             PlannedSwitches = plan.PlannedSwitches.Add(switchName, new PlannedSwitch
             {
                 Name = switchName,
-                ExternalIds = new Dictionary<string, string> {
-                    { "network_plan", plan.Id },
-                    {  "dns_records", dnsRecordsNames==default ? "": string.Join(',',dnsRecordsNames)}
-                }.ToMap()
+                ExternalIds = Map(
+                    ("network_plan", plan.Id),
+                    ("dns_records", string.Join(',', dnsRecordsNames))),
             })
         };
     }
     
-    public static NetworkPlan AddDnsRecords(this NetworkPlan plan, string id, Map<string, string> records, Map<string, string> options)
+    public static NetworkPlan AddDnsRecords(
+        this NetworkPlan plan,
+        string id,
+        Map<string, string> records,
+        Map<string, string> options)
     {
         return plan with
         {
@@ -30,86 +37,98 @@ public static class NetworkPlanConfigurationExtensions
             {
                 Records = records,
                 Options = options,
-                ExternalIds = new Dictionary<string, string> {
-                    { "network_plan", plan.Id }, 
-                    { "id", id} 
-                }.ToMap()
+                ExternalIds = Map(
+                    ("network_plan", plan.Id), 
+                    ( "id", id)),
             })
         };
     }
 
-    public static NetworkPlan AddDHCPOptions(this NetworkPlan plan, string id, IPNetwork2 cidr, Map<string, string> options)
+    public static NetworkPlan AddDHCPOptions(
+        this NetworkPlan plan,
+        string id,
+        IPNetwork2 cidr,
+        Map<string, string> options)
     {
         return plan with
         {
-            PlannedDHCPOptions =
-            plan.PlannedDHCPOptions.Add(id, new PlannedDHCPOptions
+            PlannedDHCPOptions = plan.PlannedDHCPOptions.Add(id, new PlannedDHCPOptions
             {
                 Cidr = cidr.ToString(),
                 Options = options,
-                ExternalIds = new Dictionary<string, string>
-                {
-                    { "network_plan", plan.Id },
-                    { "id", id }
-                }.ToMap()
+                ExternalIds = Map(
+                    ("network_plan", plan.Id),
+                    ("id", id)),
             })
         };
     }
 
-    public static NetworkPlan AddExternalNetworkPort(this NetworkPlan plan, string switchName, string externalNetwork, int? tag)
+    public static NetworkPlan AddExternalNetworkPort(
+        this NetworkPlan plan,
+        string switchName,
+        string externalNetwork,
+        int? tag)
     {
         var name = $"SN-{switchName}-{externalNetwork}";
+        
         return plan with
         {
-            PlannedSwitchPorts =
-            plan.PlannedSwitchPorts.Add(name, new PlannedSwitchPort(switchName)
+            PlannedSwitchPorts = plan.PlannedSwitchPorts.Add(name, new PlannedSwitchPort(switchName)
             {
                 Name = name,
                 Type = "localnet",
-                Options = new Dictionary<string, string> { { "network_name", externalNetwork } }.ToMap(),
-                Addresses = new[] { "unknown" }.ToSeq(),
-                ExternalIds = new Dictionary<string, string> { { "network_plan", plan.Id } }.ToMap(),
-                Tag = tag
+                Options = Map(("network_name", externalNetwork)),
+                Addresses = Seq1("unknown"),
+                ExternalIds = Map(("network_plan", plan.Id)),
+                Tag = tag,
             })
         };
     }
 
-    public static NetworkPlan AddNetworkPort(this NetworkPlan plan, 
+    public static NetworkPlan AddNetworkPort(
+        this NetworkPlan plan, 
         string switchName, 
-        string portName, string macAddress, IPAddress address, string dhcpOptionsV4 = "")
+        string portName,
+        string macAddress,
+        IPAddress address,
+        string dhcpOptionsV4 = "")
     {
         return plan with
         {
-            PlannedSwitchPorts =
-            plan.PlannedSwitchPorts.Add(portName, new PlannedSwitchPort(switchName)
+            PlannedSwitchPorts = plan.PlannedSwitchPorts.Add(portName, new PlannedSwitchPort(switchName)
             {
                 Name = portName,
-                Addresses = new[] { $"{macAddress} {address}"}.ToSeq(),
-                PortSecurity = new[] { $"{macAddress} {address}" }.ToSeq(),
-                ExternalIds = new Dictionary<string, string>
-                {
-                    { "network_plan", plan.Id },
-                    { "dhcp_options_v4", dhcpOptionsV4 }
-                }.ToMap()
+                Addresses = Seq1($"{macAddress} {address}"),
+                PortSecurity = Seq1($"{macAddress} {address}"),
+                ExternalIds = Map(
+                    ("network_plan", plan.Id),
+                    ("dhcp_options_v4", dhcpOptionsV4)),
             })
         };
     }
 
-    public static NetworkPlan AddRouter(this NetworkPlan plan, string routerName)
+    public static NetworkPlan AddRouter(
+        this NetworkPlan plan,
+        string routerName)
     {
         return plan with
         {
-            PlannedRouters =
-            plan.PlannedRouters.Add(routerName, new PlannedRouter
+            PlannedRouters = plan.PlannedRouters.Add(routerName, new PlannedRouter
             {
                 Name = routerName,
-                ExternalIds = new Dictionary<string, string> { { "network_plan", plan.Id } }.ToMap()
+                ExternalIds = Map(("network_plan", plan.Id)),
             })
         };
     }
 
-    public static NetworkPlan AddNATRule(this NetworkPlan plan, string routerName, string type, IPAddress externalIP, string externalMAC,
-        string logicalIP, string logicalPort = "")
+    public static NetworkPlan AddNATRule(
+        this NetworkPlan plan,
+        string routerName,
+        string type,
+        IPAddress externalIP,
+        string externalMAC,
+        string logicalIP,
+        string logicalPort = "")
     {
         var natRule = new PlannedNATRule(routerName)
         {
@@ -118,64 +137,95 @@ public static class NetworkPlanConfigurationExtensions
             ExternalMAC = externalMAC,
             LogicalIP = logicalIP,
             LogicalPort = logicalPort,
-            ExternalIds = new Dictionary<string, string>
-            {
-                { "network_plan", plan.Id },
-                { "router_name", routerName }
-            }.ToMap()
+            ExternalIds = Map(
+                ("network_plan", plan.Id),
+                ("router_name", routerName)),
         };
 
         return plan with { PlannedNATRules = plan.PlannedNATRules.Add(natRule.Name, natRule) };
     }
 
-    public static NetworkPlan AddStaticRoute(this NetworkPlan plan, string routerName, string ipPrefix, IPAddress nextHop)
+    public static NetworkPlan AddStaticRoute(
+        this NetworkPlan plan,
+        string routerName,
+        string ipPrefix,
+        IPAddress nextHop,
+        string routeTable = "")
     {
         var route = new PlannedRouterStaticRoute(routerName)
         {
             IpPrefix = ipPrefix,
             NextHop = nextHop.ToString(),
-            ExternalIds = new Dictionary<string, string>
-            {
-                { "network_plan", plan.Id },
-                { "router_name", routerName }
-            }.ToMap()
+            RouteTable = routeTable,
+            ExternalIds = Map(
+                ("network_plan", plan.Id),
+                ("router_name", routerName)),
         };
         
         return plan with { PlannedRouterStaticRoutes = plan.PlannedRouterStaticRoutes.Add(route.Name, route) };
     }
 
-    public static NetworkPlan AddRouterPort(this NetworkPlan plan, string switchName, 
-        string routerName, string macAddress, IPAddress ipAddress, IPNetwork2 network,
-        string chassisGroup = "")
+    public static NetworkPlan AddRouterPort(
+        this NetworkPlan plan,
+        string switchName, 
+        string routerName,
+        string macAddress,
+        IPAddress ipAddress,
+        IPNetwork2 network,
+        string chassisGroup = "",
+        string routeTable = "")
     {
         var portNameRouter = $"RS-{routerName}-{switchName}";
         var portNameSwitch = $"SR-{switchName}-{routerName}";
 
-        var routerExternalIds = new Dictionary<string, string> { { "network_plan", plan.Id } }.ToMap();
-        if (!string.IsNullOrWhiteSpace(chassisGroup))
-            routerExternalIds = routerExternalIds.Add("chassis_group", chassisGroup);
-        
         return plan with
         {
             PlannedRouterPorts = plan.PlannedRouterPorts.Add(portNameRouter, new PlannedRouterPort(routerName)
             {
                 Name = portNameRouter,
                 MacAddress = macAddress,
-                Networks = new Seq<string>(new[] { $"{ipAddress}/{network.Cidr}" }),
-                ExternalIds = routerExternalIds
+                Networks = Seq1($"{ipAddress}/{network.Cidr}"),
+                ExternalIds = string.IsNullOrWhiteSpace(chassisGroup)
+                    ? Map(("network_plan", plan.Id))
+                    : Map(("network_plan", plan.Id), ("chassis_group", chassisGroup)),
+                Options = string.IsNullOrWhiteSpace(routeTable)
+                    ? Map<string, string>()
+                    : Map(("route_table", routeTable)),
             }),
             PlannedSwitchPorts = plan.PlannedSwitchPorts.Add(portNameSwitch, new PlannedSwitchPort(switchName)
             {
                 Name = portNameSwitch,
                 Type = "router",
-                Addresses = new Seq<string>(new[] { "router" }),
-                Options = new Map<string, string>(new[]
-                {
+                Addresses = Seq1("router"),
+                Options = Map(
                     ("router-port", portNameRouter),
-                    ("nat-addresses", "router")
-                }),
-                ExternalIds = new Dictionary<string, string> { { "network_plan", plan.Id } }.ToMap()
-            })
+                    ("nat-addresses", "router")),
+                ExternalIds = Map(("network_plan", plan.Id)),
+            }),
+        };
+    }
+
+    public static NetworkPlan AddRouterPeerPort(
+        this NetworkPlan plan,
+        string routerName,
+        string otherRouterName,
+        string macAddress,
+        IPAddress ipAddress,
+        IPNetwork2 network)
+    {
+        var portName = $"RR-{routerName}-{otherRouterName}";
+        var otherPortName = $"RR-{otherRouterName}-{routerName}";
+
+        return plan with
+        {
+            PlannedRouterPorts = plan.PlannedRouterPorts.Add(portName, new PlannedRouterPort(routerName)
+            {
+                Name = portName,
+                MacAddress = macAddress,
+                Networks = Seq1($"{ipAddress}/{network.Cidr}"),
+                Peer = otherPortName,
+                ExternalIds = Map(("network_plan", plan.Id)),
+            }),
         };
     }
 }

--- a/src/OVN.Primitives/Model/OVN/PlannedRouterPort.cs
+++ b/src/OVN.Primitives/Model/OVN/PlannedRouterPort.cs
@@ -11,8 +11,10 @@ public record PlannedRouterPort(string RouterName) : OVSEntity, IOVSEntityWithNa
         {
             { "name", OVSValue<string>.Metadata() },
             { "mac", OVSValue<string>.Metadata() },
+            { "peer", OVSValue<string>.Metadata() },
             { "networks", OVSSet<string>.Metadata() },
             { "ha_chassis_group", OVSSet<Guid>.Metadata() },
+            { "options", OVSMap<string>.Metadata() },
         };
 
     public string? MacAddress
@@ -42,5 +44,17 @@ public record PlannedRouterPort(string RouterName) : OVSEntity, IOVSEntityWithNa
     {
         get => GetValue<string>("name");
         init => SetValue("name", value);
+    }
+
+    public string? Peer
+    {
+        get => GetValue<string>("peer");
+        init => SetValue("peer", value);
+    }
+
+    public Map<string, string> Options
+    {
+        get => GetMap<string>("options");
+        init => SetMap("options", value);
     }
 }

--- a/src/OVN.Primitives/Model/OVN/PlannedRouterStaticRoute.cs
+++ b/src/OVN.Primitives/Model/OVN/PlannedRouterStaticRoute.cs
@@ -9,7 +9,8 @@ public record PlannedRouterStaticRoute(string RouterName) : OVSEntity, IOVSEntit
         Columns = new Dictionary<string, OVSFieldMetadata>(OVSEntity.Columns)
         {
             { "ip_prefix", OVSValue<string>.Metadata() },
-            { "nexthop", OVSValue<string>.Metadata() }
+            { "nexthop", OVSValue<string>.Metadata() },
+            { "route_table", OVSValue<string>.Metadata() },
         };
 
     public string? IpPrefix
@@ -26,12 +27,18 @@ public record PlannedRouterStaticRoute(string RouterName) : OVSEntity, IOVSEntit
         init => SetValue("nexthop", value);
     }
 
+    public string? RouteTable
+    {
+        get => GetValue<string>("route_table");
+        init => SetValue("route_table", value);
+    }
 
     public OVSParentReference? GetParentReference()
     {
         return new OVSParentReference(OVNTableNames.LogicalRouter, RouterName, "static_routes");
     }
 
-    public string Name =>
-        $"router:{RouterName}, ip_prefix:{IpPrefix}";
+    public string Name => string.IsNullOrWhiteSpace(RouteTable)
+        ? $"router:{RouterName}, ip_prefix:{IpPrefix}"
+        : $"router:{RouterName}, ip_prefix:{IpPrefix}, route_table:{RouteTable}";
 }


### PR DESCRIPTION
This PR adds support for the following OVN routing features:
- router peer ports
- port-specific routing tables

Additionally, the code of the network plan extension methods has been cleaned up.