### PR TITLE
OVN 26.03 compatibility (NB 7.18 / SB 21.8) + DNAT external_mac fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,4 +44,35 @@ build of OVS and OVN is installed (the binaries must be present in the file syst
 It is not necessary to install the Hyper-V switch extension and the tests do not make
 changes to the networking settings. The integration tests only start a database process.
 
-The integration tests create a working directory under C:\ProgramData.
+The integration tests create a working directory under `C:\ProgramData\dotnet-ovn-e2e`.
+
+### Setup
+
+1. Install the dbosoft OVS/OVN package (the one shipped in `ovspackage.zip`)
+   under `C:\openvswitch\` so the layout matches:
+   - `C:\openvswitch\usr\bin\` (ovn-* / ovs-* tools)
+   - `C:\openvswitch\usr\sbin\` (ovsdb-server.exe, ovs-vswitchd.exe)
+   - `C:\openvswitch\usr\share\openvswitch\` and `...\usr\share\ovn\` (schema files)
+2. **Verify `pthreadVC3.dll` is present in BOTH `usr\bin\` and `usr\sbin\`.**
+   The package ships it in both `bin/` and `sbin/`; if you only copy `bin/pthreadVC3.dll`,
+   `ovsdb-server.exe` and `ovs-vswitchd.exe` will exit immediately with
+   `STATUS_DLL_NOT_FOUND` (0xC0000135) and the test will hang forever in
+   `WaitForDbSocket` because the spawned process dies before creating the listening socket.
+3. The eryph services that share the same install root (`ovsdb-server`,
+   `ovs-vswitchd`, `ovn-controller`) do not collide with the test instances
+   because each test uses a random working directory and its own socket path,
+   but make sure no production process is holding a lock on the install root
+   if you are re-extracting the package.
+
+### Schema versions
+
+The expected NB / SB / OVS schema versions are hard-coded in the test base
+classes (`OvnControlToolTestBase`, `OvnSouthboundControlToolTestBase`,
+`OvsControlToolTestBase`). Bump them whenever the OVS / OVN package is updated.
+Current expectations correspond to OVN 26.03 / OVS 3.7:
+
+| Database       | Schema version |
+|----------------|----------------|
+| OVN_Northbound | 7.18.0         |
+| OVN_Southbound | 21.8.0         |
+| Open_vSwitch   | 8.8.0          |

--- a/azure-piplines.yml
+++ b/azure-piplines.yml
@@ -41,7 +41,7 @@ steps:
       # See https://github.com/PowerShell/Microsoft.PowerShell.Archive/issues/77#issuecomment-601947496
       $global:ProgressPreference = 'SilentlyContinue'
       
-      Invoke-WebRequest -Uri 'https://github.com/eryph-org/eryph/raw/refs/heads/main/ovspackage-3.5.0-exp.zip' -OutFile C:\ovspackage.zip -UseBasicParsing
+      Invoke-WebRequest -Uri 'https://dbosoftreleaseseuwest.blob.core.windows.net/internal/ovn/unsigned/26.03/ovspackage.zip' -OutFile C:\ovspackage.zip -UseBasicParsing
       Expand-Archive -Path C:\ovspackage.zip -DestinationPath C:\openvswitch\usr
 
 - task: DotNetCoreCLI@2

--- a/azure-piplines.yml
+++ b/azure-piplines.yml
@@ -30,9 +30,16 @@ steps:
     projects: '**/*.csproj'
     arguments: '--configuration $(buildConfiguration)'
   
+- task: AzureCLI@2
+  displayName: download ovs package
+  inputs:
+    azureSubscription: 'WebApps (releases)'
+    scriptType: 'batch'
+    scriptLocation: 'inlineScript'
+    inlineScript: 'az storage blob download --file=C:\ovspackage.zip --container-name=internal --name=ovn/unsigned/26.03/ovspackage.zip --account-name=dbosoftreleaseseuwest'
+
 - task: PowerShell@2
   displayName: Install OVS
-  condition: true
   inputs:
     pwsh: true
     targetType: 'inline'
@@ -40,8 +47,6 @@ steps:
       # Expand-Archive is a script module and will take its preferences from the global scope.
       # See https://github.com/PowerShell/Microsoft.PowerShell.Archive/issues/77#issuecomment-601947496
       $global:ProgressPreference = 'SilentlyContinue'
-      
-      Invoke-WebRequest -Uri 'https://dbosoftreleaseseuwest.blob.core.windows.net/internal/ovn/unsigned/26.03/ovspackage.zip' -OutFile C:\ovspackage.zip -UseBasicParsing
       Expand-Archive -Path C:\ovspackage.zip -DestinationPath C:\openvswitch\usr
 
 - task: DotNetCoreCLI@2

--- a/src/OVN.Core/PlanRealizer.cs
+++ b/src/OVN.Core/PlanRealizer.cs
@@ -187,7 +187,12 @@ public abstract class PlanRealizer
         let plannedFields = plannedEntity.ToMap().Filter(IsUpdatable)
         let realizedFields = realizedEntity.ToMap().Filter(IsUpdatable)
         let addedFields = plannedFields.Except(realizedFields)
+        // Columns marked NotEmpty are schema-required and cannot be cleared
+        // (OVN 26.03 rejects `clear` on min:1 columns with "not allowed to be
+        // empty"). Drop them from removedFields; if the planned intent is to
+        // reset such a column, set it to the type's empty value explicitly.
         let removedFields = realizedFields.Except(plannedFields)
+            .Filter((name, _) => !columns.TryGetValue(name, out var meta) || !meta.NotEmpty)
         let updatedFields = plannedFields.Intersect(
                 realizedFields,
                 (name, plannedValue, realizedValue) =>

--- a/src/OVN.Primitives/Model/OVN/DHCPOptions.cs
+++ b/src/OVN.Primitives/Model/OVN/DHCPOptions.cs
@@ -9,7 +9,7 @@ public record DHCPOptions : OVSTableRecord, IOVSEntityWithName
     public new static readonly IDictionary<string, OVSFieldMetadata>
         Columns = new Dictionary<string, OVSFieldMetadata>(OVSTableRecord.Columns)
         {
-            { "cidr", OVSValue<string>.Metadata() },
+            { "cidr", OVSValue<string>.Metadata(true) },
             { "options", OVSMap<string>.Metadata() }
         };
 

--- a/src/OVN.Primitives/Model/OVN/LogicalSwitchPort.cs
+++ b/src/OVN.Primitives/Model/OVN/LogicalSwitchPort.cs
@@ -16,7 +16,7 @@ public record LogicalSwitchPort : OVSTableRecord, IHasParentReference, IOVSEntit
             { "addresses", OVSSet<string>.Metadata() },
             { "dhcpv4_options", OVSSet<Guid>.Metadata() },
             { "port_security", OVSSet<string>.Metadata() },
-            { "options", OVSMap<string>.Metadata(true) },
+            { "options", OVSMap<string>.Metadata() },
             { "tag", OVSValue<int>.Metadata() }
         };
 

--- a/src/OVN.Primitives/Model/OVN/PlannedNATRule.cs
+++ b/src/OVN.Primitives/Model/OVN/PlannedNATRule.cs
@@ -29,7 +29,7 @@ public record PlannedNATRule(string RouterName) : OVSTableRecord, IHasParentRefe
     public string? ExternalMAC
     {
         get => GetValue<string>("external_mac");
-        init => SetValue("external_mac", value);
+        init => SetValue("external_mac", string.IsNullOrWhiteSpace(value) ? null : value);
     }
 
     public string? LogicalIP
@@ -37,11 +37,11 @@ public record PlannedNATRule(string RouterName) : OVSTableRecord, IHasParentRefe
         get => GetValue<string>("logical_ip");
         init => SetValue("logical_ip", value);
     }
-    
+
     public string? LogicalPort
     {
         get => GetValue<string>("logical_port");
-        init => SetValue("logical_port", value);
+        init => SetValue("logical_port", string.IsNullOrWhiteSpace(value) ? null : value);
     }
 
     public OVSParentReference GetParentReference() =>

--- a/src/OVN.Primitives/Model/OVN/PlannedSwitchPort.cs
+++ b/src/OVN.Primitives/Model/OVN/PlannedSwitchPort.cs
@@ -4,8 +4,19 @@ using LanguageExt;
 namespace Dbosoft.OVN.Model.OVN;
 
 [PublicAPI]
-public record PlannedSwitchPort(string SwitchName) : OVSEntity, IHasParentReference, IOVSEntityWithName
+public record PlannedSwitchPort : OVSEntity, IHasParentReference, IOVSEntityWithName
 {
+    public string SwitchName { get; init; }
+
+    public PlannedSwitchPort(string switchName)
+    {
+        SwitchName = switchName;
+        // Logical_Switch_Port.type is a required column (schema min:1). OVN 26.03
+        // rejects clearing it. Seed it with "" so the realizer never diffs it as
+        // removed when the caller does not set Type explicitly (e.g. VM ports).
+        SetValue("type", "");
+    }
+
     public new static readonly IDictionary<string, OVSFieldMetadata>
         Columns = new Dictionary<string, OVSFieldMetadata>(OVSEntity.Columns)
         {
@@ -39,7 +50,7 @@ public record PlannedSwitchPort(string SwitchName) : OVSEntity, IHasParentRefere
     public string? Type
     {
         get => GetValue<string>("type");
-        init => SetValue("type", value);
+        init => SetValue("type", value ?? "");
     }
 
     public Seq<Guid> DHCPOptionsRefV4

--- a/src/OVN.Primitives/Model/OVN/PlannedSwitchPort.cs
+++ b/src/OVN.Primitives/Model/OVN/PlannedSwitchPort.cs
@@ -4,19 +4,8 @@ using LanguageExt;
 namespace Dbosoft.OVN.Model.OVN;
 
 [PublicAPI]
-public record PlannedSwitchPort : OVSEntity, IHasParentReference, IOVSEntityWithName
+public record PlannedSwitchPort(string SwitchName) : OVSEntity, IHasParentReference, IOVSEntityWithName
 {
-    public string SwitchName { get; init; }
-
-    public PlannedSwitchPort(string switchName)
-    {
-        SwitchName = switchName;
-        // Logical_Switch_Port.type is a required column (schema min:1). OVN 26.03
-        // rejects clearing it. Seed it with "" so the realizer never diffs it as
-        // removed when the caller does not set Type explicitly (e.g. VM ports).
-        SetValue("type", "");
-    }
-
     public new static readonly IDictionary<string, OVSFieldMetadata>
         Columns = new Dictionary<string, OVSFieldMetadata>(OVSEntity.Columns)
         {
@@ -50,7 +39,7 @@ public record PlannedSwitchPort : OVSEntity, IHasParentReference, IOVSEntityWith
     public string? Type
     {
         get => GetValue<string>("type");
-        init => SetValue("type", value ?? "");
+        init => SetValue("type", value);
     }
 
     public Seq<Guid> DHCPOptionsRefV4

--- a/src/OVNAgent/NetworkPlanParser.cs
+++ b/src/OVNAgent/NetworkPlanParser.cs
@@ -215,8 +215,8 @@ public static class NetworkPlanParser
             var natType = "";
             var externalIPString = "";
             var logicalIP = "";
-            var externalMac = "";
-            var logicalPort = "";
+            string? externalMac = null;
+            string? logicalPort = null;
             if (natValues.ContainsKey("snat"))
             {
                 natType = "snat";
@@ -263,7 +263,7 @@ public static class NetworkPlanParser
                 throw new InvalidDataException(
                     $"ip address {externalIPString} is invalid for router nat (router: {routerName}).");
             
-            return networkPlan.AddNATRule(routerName, natType, ipAddress, externalMac, logicalIP, logicalPort);
+            return networkPlan.AddNATRule(routerName, natType, ipAddress, externalMac ?? "", logicalIP, logicalPort ?? "");
         }
         
         NetworkPlan ParseRouterRoutes(NetworkPlan networkPlan, 

--- a/test/OVN.Core.IntegrationTests/ClusterPlanNorthboundRealizerTests.ApplyClusterPlan_ChassisGroupChanged_IsSuccessful.verified.txt
+++ b/test/OVN.Core.IntegrationTests/ClusterPlanNorthboundRealizerTests.ApplyClusterPlan_ChassisGroupChanged_IsSuccessful.verified.txt
@@ -1,6 +1,6 @@
 ﻿ACL table
-_uuid action direction external_ids label log match meter name options priority sample_est sample_new severity tier
------ ------ --------- ------------ ----- --- ----- ----- ---- ------- -------- ---------- ---------- -------- ----
+_uuid action direction external_ids label log match meter name network_function_group options priority sample_est sample_new severity tier
+----- ------ --------- ------------ ----- --- ----- ----- ---- ---------------------- ------- -------- ---------- ---------- -------- ----
 
 Address_Set table
 _uuid addresses external_ids name
@@ -70,8 +70,8 @@ _uuid copp enabled external_ids load_balancer load_balancer_group name nat optio
 ----- ---- ------- ------------ ------------- ------------------- ---- --- ------- -------- ----- -------------
 
 Logical_Router_Policy table
-_uuid action bfd_sessions chain external_ids jump_chain match nexthop nexthops options priority
------ ------ ------------ ----- ------------ ---------- ----- ------- -------- ------- --------
+_uuid action bfd_sessions chain external_ids jump_chain match nexthop nexthops options output_port priority
+----- ------ ------------ ----- ------------ ---------- ----- ------- -------- ------- ----------- --------
 
 Logical_Router_Port table
 _uuid dhcp_relay enabled external_ids gateway_chassis ha_chassis_group ipv6_prefix ipv6_ra_configs mac name networks options peer status
@@ -86,8 +86,12 @@ _uuid acls copp dns_records external_ids forwarding_groups load_balancer load_ba
 ----- ---- ---- ----------- ------------ ----------------- ------------- ------------------- ---- ------------ ----- ---------
 
 Logical_Switch_Port table
-_uuid addresses dhcpv4_options dhcpv6_options dynamic_addresses enabled external_ids ha_chassis_group mirror_rules name options parent_name peer port_security tag tag_request type up
------ --------- -------------- -------------- ----------------- ------- ------------ ---------------- ------------ ---- ------- ----------- ---- ------------- --- ----------- ---- --
+_uuid addresses dhcpv4_options dhcpv6_options dynamic_addresses enabled external_ids ha_chassis_group health_checks mirror_rules name options parent_name peer port_security tag tag_request type up
+----- --------- -------------- -------------- ----------------- ------- ------------ ---------------- ------------- ------------ ---- ------- ----------- ---- ------------- --- ----------- ---- --
+
+Logical_Switch_Port_Health_Check table
+_uuid address options port protocol src_ip status
+----- ------- ------- ---- -------- ------ ------
 
 Meter table
 _uuid bands external_ids fair name unit
@@ -98,8 +102,12 @@ _uuid action burst_size external_ids rate
 ----- ------ ---------- ------------ ----
 
 Mirror table
-_uuid external_ids filter index name sink type
------ ------------ ------ ----- ---- ---- ----
+_uuid external_ids filter index mirror_rules name sink type
+----- ------------ ------ ----- ------------ ---- ---- ----
+
+Mirror_Rule table
+_uuid action match priority
+----- ------ ----- --------
 
 NAT table
 _uuid allowed_ext_ips exempted_ext_ips external_ids external_ip external_mac external_port_range gateway_port logical_ip logical_port match options priority type
@@ -109,6 +117,18 @@ NB_Global table
 _uuid                                connections external_ids hv_cfg hv_cfg_timestamp ipsec name nb_cfg nb_cfg_timestamp options sb_cfg sb_cfg_timestamp ssl
 ------------------------------------ ----------- ------------ ------ ---------------- ----- ---- ------ ---------------- ------- ------ ---------------- ---
 Guid_0000000000000000000000000000004 []          {}           0      0                false ""   0      0                {}      0      0                []
+
+Network_Function table
+_uuid external_ids health_check id inport name outport
+----- ------------ ------------ -- ------ ---- -------
+
+Network_Function_Group table
+_uuid external_ids fallback id mode name network_function network_function_active
+----- ------------ -------- -- ---- ---- ---------------- -----------------------
+
+Network_Function_Health_Check table
+_uuid external_ids name options
+----- ------------ ---- -------
 
 Port_Group table
 _uuid acls external_ids name ports

--- a/test/OVN.Core.IntegrationTests/ClusterPlanNorthboundRealizerTests.ApplyClusterPlan_NewPlan_IsSuccessful.verified.txt
+++ b/test/OVN.Core.IntegrationTests/ClusterPlanNorthboundRealizerTests.ApplyClusterPlan_NewPlan_IsSuccessful.verified.txt
@@ -1,6 +1,6 @@
 ﻿ACL table
-_uuid action direction external_ids label log match meter name options priority sample_est sample_new severity tier
------ ------ --------- ------------ ----- --- ----- ----- ---- ------- -------- ---------- ---------- -------- ----
+_uuid action direction external_ids label log match meter name network_function_group options priority sample_est sample_new severity tier
+----- ------ --------- ------------ ----- --- ----- ----- ---- ---------------------- ------- -------- ---------- ---------- -------- ----
 
 Address_Set table
 _uuid addresses external_ids name
@@ -70,8 +70,8 @@ _uuid copp enabled external_ids load_balancer load_balancer_group name nat optio
 ----- ---- ------- ------------ ------------- ------------------- ---- --- ------- -------- ----- -------------
 
 Logical_Router_Policy table
-_uuid action bfd_sessions chain external_ids jump_chain match nexthop nexthops options priority
------ ------ ------------ ----- ------------ ---------- ----- ------- -------- ------- --------
+_uuid action bfd_sessions chain external_ids jump_chain match nexthop nexthops options output_port priority
+----- ------ ------------ ----- ------------ ---------- ----- ------- -------- ------- ----------- --------
 
 Logical_Router_Port table
 _uuid dhcp_relay enabled external_ids gateway_chassis ha_chassis_group ipv6_prefix ipv6_ra_configs mac name networks options peer status
@@ -86,8 +86,12 @@ _uuid acls copp dns_records external_ids forwarding_groups load_balancer load_ba
 ----- ---- ---- ----------- ------------ ----------------- ------------- ------------------- ---- ------------ ----- ---------
 
 Logical_Switch_Port table
-_uuid addresses dhcpv4_options dhcpv6_options dynamic_addresses enabled external_ids ha_chassis_group mirror_rules name options parent_name peer port_security tag tag_request type up
------ --------- -------------- -------------- ----------------- ------- ------------ ---------------- ------------ ---- ------- ----------- ---- ------------- --- ----------- ---- --
+_uuid addresses dhcpv4_options dhcpv6_options dynamic_addresses enabled external_ids ha_chassis_group health_checks mirror_rules name options parent_name peer port_security tag tag_request type up
+----- --------- -------------- -------------- ----------------- ------- ------------ ---------------- ------------- ------------ ---- ------- ----------- ---- ------------- --- ----------- ---- --
+
+Logical_Switch_Port_Health_Check table
+_uuid address options port protocol src_ip status
+----- ------- ------- ---- -------- ------ ------
 
 Meter table
 _uuid bands external_ids fair name unit
@@ -98,8 +102,12 @@ _uuid action burst_size external_ids rate
 ----- ------ ---------- ------------ ----
 
 Mirror table
-_uuid external_ids filter index name sink type
------ ------------ ------ ----- ---- ---- ----
+_uuid external_ids filter index mirror_rules name sink type
+----- ------------ ------ ----- ------------ ---- ---- ----
+
+Mirror_Rule table
+_uuid action match priority
+----- ------ ----- --------
 
 NAT table
 _uuid allowed_ext_ips exempted_ext_ips external_ids external_ip external_mac external_port_range gateway_port logical_ip logical_port match options priority type
@@ -109,6 +117,18 @@ NB_Global table
 _uuid                                connections external_ids hv_cfg hv_cfg_timestamp ipsec name nb_cfg nb_cfg_timestamp options sb_cfg sb_cfg_timestamp ssl
 ------------------------------------ ----------- ------------ ------ ---------------- ----- ---- ------ ---------------- ------- ------ ---------------- ---
 Guid_0000000000000000000000000000004 []          {}           0      0                false ""   0      0                {}      0      0                []
+
+Network_Function table
+_uuid external_ids health_check id inport name outport
+----- ------------ ------------ -- ------ ---- -------
+
+Network_Function_Group table
+_uuid external_ids fallback id mode name network_function network_function_active
+----- ------------ -------- -- ---- ---- ---------------- -----------------------
+
+Network_Function_Health_Check table
+_uuid external_ids name options
+----- ------------ ---- -------
 
 Port_Group table
 _uuid acls external_ids name ports

--- a/test/OVN.Core.IntegrationTests/ClusterPlanNorthboundRealizerTests.ApplyClusterPlan_RemoveChassisFromGroup_IsSuccessful.verified.txt
+++ b/test/OVN.Core.IntegrationTests/ClusterPlanNorthboundRealizerTests.ApplyClusterPlan_RemoveChassisFromGroup_IsSuccessful.verified.txt
@@ -1,6 +1,6 @@
 ﻿ACL table
-_uuid action direction external_ids label log match meter name options priority sample_est sample_new severity tier
------ ------ --------- ------------ ----- --- ----- ----- ---- ------- -------- ---------- ---------- -------- ----
+_uuid action direction external_ids label log match meter name network_function_group options priority sample_est sample_new severity tier
+----- ------ --------- ------------ ----- --- ----- ----- ---- ---------------------- ------- -------- ---------- ---------- -------- ----
 
 Address_Set table
 _uuid addresses external_ids name
@@ -69,8 +69,8 @@ _uuid copp enabled external_ids load_balancer load_balancer_group name nat optio
 ----- ---- ------- ------------ ------------- ------------------- ---- --- ------- -------- ----- -------------
 
 Logical_Router_Policy table
-_uuid action bfd_sessions chain external_ids jump_chain match nexthop nexthops options priority
------ ------ ------------ ----- ------------ ---------- ----- ------- -------- ------- --------
+_uuid action bfd_sessions chain external_ids jump_chain match nexthop nexthops options output_port priority
+----- ------ ------------ ----- ------------ ---------- ----- ------- -------- ------- ----------- --------
 
 Logical_Router_Port table
 _uuid dhcp_relay enabled external_ids gateway_chassis ha_chassis_group ipv6_prefix ipv6_ra_configs mac name networks options peer status
@@ -85,8 +85,12 @@ _uuid acls copp dns_records external_ids forwarding_groups load_balancer load_ba
 ----- ---- ---- ----------- ------------ ----------------- ------------- ------------------- ---- ------------ ----- ---------
 
 Logical_Switch_Port table
-_uuid addresses dhcpv4_options dhcpv6_options dynamic_addresses enabled external_ids ha_chassis_group mirror_rules name options parent_name peer port_security tag tag_request type up
------ --------- -------------- -------------- ----------------- ------- ------------ ---------------- ------------ ---- ------- ----------- ---- ------------- --- ----------- ---- --
+_uuid addresses dhcpv4_options dhcpv6_options dynamic_addresses enabled external_ids ha_chassis_group health_checks mirror_rules name options parent_name peer port_security tag tag_request type up
+----- --------- -------------- -------------- ----------------- ------- ------------ ---------------- ------------- ------------ ---- ------- ----------- ---- ------------- --- ----------- ---- --
+
+Logical_Switch_Port_Health_Check table
+_uuid address options port protocol src_ip status
+----- ------- ------- ---- -------- ------ ------
 
 Meter table
 _uuid bands external_ids fair name unit
@@ -97,8 +101,12 @@ _uuid action burst_size external_ids rate
 ----- ------ ---------- ------------ ----
 
 Mirror table
-_uuid external_ids filter index name sink type
------ ------------ ------ ----- ---- ---- ----
+_uuid external_ids filter index mirror_rules name sink type
+----- ------------ ------ ----- ------------ ---- ---- ----
+
+Mirror_Rule table
+_uuid action match priority
+----- ------ ----- --------
 
 NAT table
 _uuid allowed_ext_ips exempted_ext_ips external_ids external_ip external_mac external_port_range gateway_port logical_ip logical_port match options priority type
@@ -108,6 +116,18 @@ NB_Global table
 _uuid                                connections external_ids hv_cfg hv_cfg_timestamp ipsec name nb_cfg nb_cfg_timestamp options sb_cfg sb_cfg_timestamp ssl
 ------------------------------------ ----------- ------------ ------ ---------------- ----- ---- ------ ---------------- ------- ------ ---------------- ---
 Guid_0000000000000000000000000000003 []          {}           0      0                false ""   0      0                {}      0      0                []
+
+Network_Function table
+_uuid external_ids health_check id inport name outport
+----- ------------ ------------ -- ------ ---- -------
+
+Network_Function_Group table
+_uuid external_ids fallback id mode name network_function network_function_active
+----- ------------ -------- -- ---- ---- ---------------- -----------------------
+
+Network_Function_Health_Check table
+_uuid external_ids name options
+----- ------------ ---- -------
 
 Port_Group table
 _uuid acls external_ids name ports

--- a/test/OVN.Core.IntegrationTests/ClusterPlanSouthboundRealizerTests.ApplyClusterPlan_NewPlan_IsSuccessful.verified.txt
+++ b/test/OVN.Core.IntegrationTests/ClusterPlanSouthboundRealizerTests.ApplyClusterPlan_NewPlan_IsSuccessful.verified.txt
@@ -6,6 +6,10 @@ Address_Set table
 _uuid addresses name
 ----- --------- ----
 
+Advertised_MAC_Binding table
+_uuid datapath external_ids ip logical_port mac
+----- -------- ------------ -- ------------ ---
+
 Advertised_Route table
 _uuid datapath external_ids ip_prefix logical_port tracked_port
 ----- -------- ------------ --------- ------------ ------------
@@ -49,8 +53,8 @@ _uuid datapaths external_ids options records
 ----- --------- ------------ ------- -------
 
 Datapath_Binding table
-_uuid external_ids load_balancers tunnel_key
------ ------------ -------------- ----------
+_uuid external_ids load_balancers nb_uuid tunnel_key type
+----- ------------ -------------- ------- ---------- ----
 
 ECMP_Nexthop table
 _uuid datapath external_ids mac nexthop port
@@ -121,8 +125,8 @@ _uuid datapath name ports tunnel_key
 ----- -------- ---- ----- ----------
 
 Port_Binding table
-_uuid additional_chassis additional_encap chassis datapath encap external_ids gateway_chassis ha_chassis_group logical_port mac mirror_rules nat_addresses options parent_port port_security requested_additional_chassis requested_chassis tag tunnel_key type up virtual_parent
------ ------------------ ---------------- ------- -------- ----- ------------ --------------- ---------------- ------------ --- ------------ ------------- ------- ----------- ------------- ---------------------------- ----------------- --- ---------- ---- -- --------------
+_uuid additional_chassis additional_encap chassis datapath encap external_ids gateway_chassis ha_chassis_group logical_port mac mirror_port mirror_rules nat_addresses options parent_port port_security requested_additional_chassis requested_chassis tag tunnel_key type up virtual_parent
+----- ------------------ ---------------- ------- -------- ----- ------------ --------------- ---------------- ------------ --- ----------- ------------ ------------- ------- ----------- ------------- ---------------------------- ----------------- --- ---------- ---- -- --------------
 
 Port_Group table
 _uuid name ports
@@ -147,8 +151,8 @@ _uuid                                bootstrap_ca_cert ca_cert                  
 Guid_0000000000000000000000000000004 false             "{OvsTestDirectory________________________}/etc/openvswitch/cacert_SHA256_000000000000000000000000000000000000000000000000000000001.pem" "{OvsTestDirectory________________________}/etc/openvswitch/cert_SHA256_000000000000000000000000000000000000000000000000000000002.pem" {}           "{OvsTestDirectory________________________}/etc/openvswitch/private/key_SHA256_000000000000000000000000000000000000000000000000000000003.pem" ""          ""               "TLSv1.3,TLSv1.2"
 
 Service_Monitor table
-_uuid chassis_name external_ids ip logical_port options port protocol src_ip src_mac status
------ ------------ ------------ -- ------------ ------- ---- -------- ------ ------- ------
+_uuid chassis_name external_ids ic_learned ip logical_input_port logical_port mac options port protocol remote src_ip src_mac status type
+----- ------------ ------------ ---------- -- ------------------ ------------ --- ------- ---- -------- ------ ------ ------- ------ ----
 
 Static_MAC_Binding table
 _uuid datapath ip logical_port mac override_dynamic_mac

--- a/test/OVN.Core.IntegrationTests/ClusterPlanSouthboundRealizerTests.ApplyClusterPlan_UpdatedPlan_IsSuccessful.verified.txt
+++ b/test/OVN.Core.IntegrationTests/ClusterPlanSouthboundRealizerTests.ApplyClusterPlan_UpdatedPlan_IsSuccessful.verified.txt
@@ -6,6 +6,10 @@ Address_Set table
 _uuid addresses name
 ----- --------- ----
 
+Advertised_MAC_Binding table
+_uuid datapath external_ids ip logical_port mac
+----- -------- ------------ -- ------------ ---
+
 Advertised_Route table
 _uuid datapath external_ids ip_prefix logical_port tracked_port
 ----- -------- ------------ --------- ------------ ------------
@@ -49,8 +53,8 @@ _uuid datapaths external_ids options records
 ----- --------- ------------ ------- -------
 
 Datapath_Binding table
-_uuid external_ids load_balancers tunnel_key
------ ------------ -------------- ----------
+_uuid external_ids load_balancers nb_uuid tunnel_key type
+----- ------------ -------------- ------- ---------- ----
 
 ECMP_Nexthop table
 _uuid datapath external_ids mac nexthop port
@@ -121,8 +125,8 @@ _uuid datapath name ports tunnel_key
 ----- -------- ---- ----- ----------
 
 Port_Binding table
-_uuid additional_chassis additional_encap chassis datapath encap external_ids gateway_chassis ha_chassis_group logical_port mac mirror_rules nat_addresses options parent_port port_security requested_additional_chassis requested_chassis tag tunnel_key type up virtual_parent
------ ------------------ ---------------- ------- -------- ----- ------------ --------------- ---------------- ------------ --- ------------ ------------- ------- ----------- ------------- ---------------------------- ----------------- --- ---------- ---- -- --------------
+_uuid additional_chassis additional_encap chassis datapath encap external_ids gateway_chassis ha_chassis_group logical_port mac mirror_port mirror_rules nat_addresses options parent_port port_security requested_additional_chassis requested_chassis tag tunnel_key type up virtual_parent
+----- ------------------ ---------------- ------- -------- ----- ------------ --------------- ---------------- ------------ --- ----------- ------------ ------------- ------- ----------- ------------- ---------------------------- ----------------- --- ---------- ---- -- --------------
 
 Port_Group table
 _uuid name ports
@@ -147,8 +151,8 @@ _uuid                                bootstrap_ca_cert ca_cert                  
 Guid_0000000000000000000000000000004 false             "{OvsTestDirectory________________________}/etc/openvswitch/cacert_SHA256_000000000000000000000000000000000000000000000000000000001.pem" "{OvsTestDirectory________________________}/etc/openvswitch/cert_SHA256_000000000000000000000000000000000000000000000000000000002.pem" {}           "{OvsTestDirectory________________________}/etc/openvswitch/private/key_SHA256_000000000000000000000000000000000000000000000000000000003.pem" ""          ""               "TLSv1.3,TLSv1.2"
 
 Service_Monitor table
-_uuid chassis_name external_ids ip logical_port options port protocol src_ip src_mac status
------ ------------ ------------ -- ------------ ------- ---- -------- ------ ------- ------
+_uuid chassis_name external_ids ic_learned ip logical_input_port logical_port mac options port protocol remote src_ip src_mac status type
+----- ------------ ------------ ---------- -- ------------------ ------------ --- ------- ---- -------- ------ ------ ------- ------ ----
 
 Static_MAC_Binding table
 _uuid datapath ip logical_port mac override_dynamic_mac

--- a/test/OVN.Core.IntegrationTests/NetworkPlanRealizerTests.ApplyNetworkPlan_NewPlan_PlanIsApplied.verified.txt
+++ b/test/OVN.Core.IntegrationTests/NetworkPlanRealizerTests.ApplyNetworkPlan_NewPlan_PlanIsApplied.verified.txt
@@ -1,6 +1,6 @@
 ﻿ACL table
-_uuid action direction external_ids label log match meter name options priority sample_est sample_new severity tier
------ ------ --------- ------------ ----- --- ----- ----- ---- ------- -------- ---------- ---------- -------- ----
+_uuid action direction external_ids label log match meter name network_function_group options priority sample_est sample_new severity tier
+----- ------ --------- ------------ ----- --- ----- ----- ---- ---------------------- ------- -------- ---------- ---------- -------- ----
 
 Address_Set table
 _uuid addresses external_ids name
@@ -70,8 +70,8 @@ _uuid                                copp enabled external_ids                lo
 Guid_0000000000000000000000000000003 []   []      {network_plan=test-project} []            []                  router-1 [Guid_0000000000000000000000000000004, Guid_0000000000000000000000000000005] {}      []       [Guid_0000000000000000000000000000006, Guid_0000000000000000000000000000007] [Guid_0000000000000000000000000000008]
 
 Logical_Router_Policy table
-_uuid action bfd_sessions chain external_ids jump_chain match nexthop nexthops options priority
------ ------ ------------ ----- ------------ ---------- ----- ------- -------- ------- --------
+_uuid action bfd_sessions chain external_ids jump_chain match nexthop nexthops options output_port priority
+----- ------ ------------ ----- ------------ ---------- ----- ------- -------- ------- ----------- --------
 
 Logical_Router_Port table
 _uuid                                dhcp_relay enabled external_ids                                     gateway_chassis ha_chassis_group ipv6_prefix ipv6_ra_configs mac                 name                          networks            options peer status
@@ -91,12 +91,16 @@ Guid_0000000000000000000000000000009 []   []   []          {dns_records="", netw
 Guid_0000000000000000000000000000012 []   []   []          {dns_records="", network_plan=test-project} []                []            []                  switch-1          {}           [Guid_0000000000000000000000000000013, Guid_0000000000000000000000000000014] []
 
 Logical_Switch_Port table
-_uuid                                addresses                            dhcpv4_options                       dhcpv6_options dynamic_addresses enabled external_ids                                        ha_chassis_group mirror_rules name                          options                                                           parent_name peer port_security                        tag tag_request type     up
------------------------------------- ------------------------------------ ------------------------------------ -------------- ----------------- ------- --------------------------------------------------- ---------------- ------------ ----------------------------- ----------------------------------------------------------------- ----------- ---- ------------------------------------ --- ----------- -------- --
-Guid_0000000000000000000000000000014 ["02:01:00:00:00:01 198.51.100.100"] Guid_0000000000000000000000000000001 []             []                []      {dhcp_options_v4=dhcp-1, network_plan=test-project} []               []           switch-1-port-1               {}                                                                []          []   ["02:01:00:00:00:01 198.51.100.100"] []  []          ""       []
-Guid_0000000000000000000000000000011 [router]                             []                                   []             []                []      {network_plan=test-project}                         []               []           SR-provider-switch-1-router-1 {nat-addresses=router, router-port=RS-router-1-provider-switch-1} []          []   []                                   []  []          router   []
-Guid_0000000000000000000000000000013 [router]                             []                                   []             []                []      {network_plan=test-project}                         []               []           SR-switch-1-router-1          {nat-addresses=router, router-port=RS-router-1-switch-1}          []          []   []                                   []  []          router   []
-Guid_0000000000000000000000000000010 [unknown]                            []                                   []             []                []      {network_plan=test-project}                         []               []           SN-provider-switch-1-extern   {network_name=extern}                                             []          []   []                                   5   []          localnet []
+_uuid                                addresses                            dhcpv4_options                       dhcpv6_options dynamic_addresses enabled external_ids                                        ha_chassis_group health_checks mirror_rules name                          options                                                           parent_name peer port_security                        tag tag_request type     up
+------------------------------------ ------------------------------------ ------------------------------------ -------------- ----------------- ------- --------------------------------------------------- ---------------- ------------- ------------ ----------------------------- ----------------------------------------------------------------- ----------- ---- ------------------------------------ --- ----------- -------- --
+Guid_0000000000000000000000000000014 ["02:01:00:00:00:01 198.51.100.100"] Guid_0000000000000000000000000000001 []             []                []      {dhcp_options_v4=dhcp-1, network_plan=test-project} []               []            []           switch-1-port-1               {}                                                                []          []   ["02:01:00:00:00:01 198.51.100.100"] []  []          ""       []
+Guid_0000000000000000000000000000011 [router]                             []                                   []             []                []      {network_plan=test-project}                         []               []            []           SR-provider-switch-1-router-1 {nat-addresses=router, router-port=RS-router-1-provider-switch-1} []          []   []                                   []  []          router   []
+Guid_0000000000000000000000000000013 [router]                             []                                   []             []                []      {network_plan=test-project}                         []               []            []           SR-switch-1-router-1          {nat-addresses=router, router-port=RS-router-1-switch-1}          []          []   []                                   []  []          router   []
+Guid_0000000000000000000000000000010 [unknown]                            []                                   []             []                []      {network_plan=test-project}                         []               []            []           SN-provider-switch-1-extern   {network_name=extern}                                             []          []   []                                   5   []          localnet []
+
+Logical_Switch_Port_Health_Check table
+_uuid address options port protocol src_ip status
+----- ------- ------- ---- -------- ------ ------
 
 Meter table
 _uuid bands external_ids fair name unit
@@ -107,8 +111,12 @@ _uuid action burst_size external_ids rate
 ----- ------ ---------- ------------ ----
 
 Mirror table
-_uuid external_ids filter index name sink type
------ ------------ ------ ----- ---- ---- ----
+_uuid external_ids filter index mirror_rules name sink type
+----- ------------ ------ ----- ------------ ---- ---- ----
+
+Mirror_Rule table
+_uuid action match priority
+----- ------ ----- --------
 
 NAT table
 _uuid                                allowed_ext_ips exempted_ext_ips external_ids                                      external_ip   external_mac        external_port_range gateway_port logical_ip        logical_port match options priority type
@@ -120,6 +128,18 @@ NB_Global table
 _uuid                                connections external_ids hv_cfg hv_cfg_timestamp ipsec name nb_cfg nb_cfg_timestamp options sb_cfg sb_cfg_timestamp ssl
 ------------------------------------ ----------- ------------ ------ ---------------- ----- ---- ------ ---------------- ------- ------ ---------------- ---
 Guid_0000000000000000000000000000015 []          {}           0      0                false ""   0      0                {}      0      0                []
+
+Network_Function table
+_uuid external_ids health_check id inport name outport
+----- ------------ ------------ -- ------ ---- -------
+
+Network_Function_Group table
+_uuid external_ids fallback id mode name network_function network_function_active
+----- ------------ -------- -- ---- ---- ---------------- -----------------------
+
+Network_Function_Health_Check table
+_uuid external_ids name options
+----- ------------ ---- -------
 
 Port_Group table
 _uuid acls external_ids name ports

--- a/test/OVN.Core.IntegrationTests/NetworkPlanRealizerTests.ApplyNetworkPlan_NewPlan_PlanIsApplied.verified.txt
+++ b/test/OVN.Core.IntegrationTests/NetworkPlanRealizerTests.ApplyNetworkPlan_NewPlan_PlanIsApplied.verified.txt
@@ -114,7 +114,7 @@ NAT table
 _uuid                                allowed_ext_ips exempted_ext_ips external_ids                                      external_ip   external_mac        external_port_range gateway_port logical_ip        logical_port match options priority type
 ------------------------------------ --------------- ---------------- ------------------------------------------------- ------------- ------------------- ------------------- ------------ ----------------- ------------ ----- ------- -------- -------------
 Guid_0000000000000000000000000000005 []              []               {network_plan=test-project, router_name=router-1} "192.0.2.100" []                  ""                  []           "198.51.100.0/24" []           ""    {}      0        snat
-Guid_0000000000000000000000000000004 []              []               {network_plan=test-project, router_name=router-1} "192.0.2.110" "02:00:00:00:00:03" ""                  []           "198.51.100.100"  ""           ""    {}      0        dnat_and_snat
+Guid_0000000000000000000000000000004 []              []               {network_plan=test-project, router_name=router-1} "192.0.2.110" "02:00:00:00:00:03" ""                  []           "198.51.100.100"  []           ""    {}      0        dnat_and_snat
 
 NB_Global table
 _uuid                                connections external_ids hv_cfg hv_cfg_timestamp ipsec name nb_cfg nb_cfg_timestamp options sb_cfg sb_cfg_timestamp ssl

--- a/test/OVN.Core.IntegrationTests/NetworkPlanRealizerTests.ApplyNetworkPlan_RemoveChildResources_PlanIsApplied.verified.txt
+++ b/test/OVN.Core.IntegrationTests/NetworkPlanRealizerTests.ApplyNetworkPlan_RemoveChildResources_PlanIsApplied.verified.txt
@@ -1,6 +1,6 @@
 ﻿ACL table
-_uuid action direction external_ids label log match meter name options priority sample_est sample_new severity tier
------ ------ --------- ------------ ----- --- ----- ----- ---- ------- -------- ---------- ---------- -------- ----
+_uuid action direction external_ids label log match meter name network_function_group options priority sample_est sample_new severity tier
+----- ------ --------- ------------ ----- --- ----- ----- ---- ---------------------- ------- -------- ---------- ---------- -------- ----
 
 Address_Set table
 _uuid addresses external_ids name
@@ -68,8 +68,8 @@ _uuid                                copp enabled external_ids                lo
 Guid_0000000000000000000000000000001 []   []      {network_plan=test-project} []            []                  router-1 []  {}      []       []    []
 
 Logical_Router_Policy table
-_uuid action bfd_sessions chain external_ids jump_chain match nexthop nexthops options priority
------ ------ ------------ ----- ------------ ---------- ----- ------- -------- ------- --------
+_uuid action bfd_sessions chain external_ids jump_chain match nexthop nexthops options output_port priority
+----- ------ ------------ ----- ------------ ---------- ----- ------- -------- ------- ----------- --------
 
 Logical_Router_Port table
 _uuid dhcp_relay enabled external_ids gateway_chassis ha_chassis_group ipv6_prefix ipv6_ra_configs mac name networks options peer status
@@ -86,8 +86,12 @@ Guid_0000000000000000000000000000002 []   []   []          {dns_records="", netw
 Guid_0000000000000000000000000000003 []   []   []          {dns_records="", network_plan=test-project} []                []            []                  switch-1          {}           []    []
 
 Logical_Switch_Port table
-_uuid addresses dhcpv4_options dhcpv6_options dynamic_addresses enabled external_ids ha_chassis_group mirror_rules name options parent_name peer port_security tag tag_request type up
------ --------- -------------- -------------- ----------------- ------- ------------ ---------------- ------------ ---- ------- ----------- ---- ------------- --- ----------- ---- --
+_uuid addresses dhcpv4_options dhcpv6_options dynamic_addresses enabled external_ids ha_chassis_group health_checks mirror_rules name options parent_name peer port_security tag tag_request type up
+----- --------- -------------- -------------- ----------------- ------- ------------ ---------------- ------------- ------------ ---- ------- ----------- ---- ------------- --- ----------- ---- --
+
+Logical_Switch_Port_Health_Check table
+_uuid address options port protocol src_ip status
+----- ------- ------- ---- -------- ------ ------
 
 Meter table
 _uuid bands external_ids fair name unit
@@ -98,8 +102,12 @@ _uuid action burst_size external_ids rate
 ----- ------ ---------- ------------ ----
 
 Mirror table
-_uuid external_ids filter index name sink type
------ ------------ ------ ----- ---- ---- ----
+_uuid external_ids filter index mirror_rules name sink type
+----- ------------ ------ ----- ------------ ---- ---- ----
+
+Mirror_Rule table
+_uuid action match priority
+----- ------ ----- --------
 
 NAT table
 _uuid allowed_ext_ips exempted_ext_ips external_ids external_ip external_mac external_port_range gateway_port logical_ip logical_port match options priority type
@@ -109,6 +117,18 @@ NB_Global table
 _uuid                                connections external_ids hv_cfg hv_cfg_timestamp ipsec name nb_cfg nb_cfg_timestamp options sb_cfg sb_cfg_timestamp ssl
 ------------------------------------ ----------- ------------ ------ ---------------- ----- ---- ------ ---------------- ------- ------ ---------------- ---
 Guid_0000000000000000000000000000004 []          {}           0      0                false ""   0      0                {}      0      0                []
+
+Network_Function table
+_uuid external_ids health_check id inport name outport
+----- ------------ ------------ -- ------ ---- -------
+
+Network_Function_Group table
+_uuid external_ids fallback id mode name network_function network_function_active
+----- ------------ -------- -- ---- ---- ---------------- -----------------------
+
+Network_Function_Health_Check table
+_uuid external_ids name options
+----- ------------ ---- -------
 
 Port_Group table
 _uuid acls external_ids name ports

--- a/test/OVN.Core.IntegrationTests/NetworkPlanRealizerTests.ApplyNetworkPlan_SamePlanTwice_NoClearOnRequiredColumns.verified.txt
+++ b/test/OVN.Core.IntegrationTests/NetworkPlanRealizerTests.ApplyNetworkPlan_SamePlanTwice_NoClearOnRequiredColumns.verified.txt
@@ -1,0 +1,170 @@
+﻿ACL table
+_uuid action direction external_ids label log match meter name network_function_group options priority sample_est sample_new severity tier
+----- ------ --------- ------------ ----- --- ----- ----- ---- ---------------------- ------- -------- ---------- ---------- -------- ----
+
+Address_Set table
+_uuid addresses external_ids name
+----- --------- ------------ ----
+
+BFD table
+_uuid detect_mult dst_ip external_ids logical_port min_rx min_tx options status
+----- ----------- ------ ------------ ------------ ------ ------ ------- ------
+
+Chassis_Template_Var table
+_uuid chassis external_ids variables
+----- ------- ------------ ---------
+
+Connection table
+_uuid external_ids inactivity_probe is_connected max_backoff other_config status target
+----- ------------ ---------------- ------------ ----------- ------------ ------ ------
+
+Copp table
+_uuid external_ids meters name
+----- ------------ ------ ----
+
+DHCP_Options table
+_uuid                                cidr              external_ids                           options
+------------------------------------ ----------------- -------------------------------------- -------
+Guid_0000000000000000000000000000001 "198.51.100.0/24" {id=dhcp-1, network_plan=test-project} {}
+
+DHCP_Relay table
+_uuid external_ids name options servers
+----- ------------ ---- ------- -------
+
+DNS table
+_uuid                                external_ids                          options records
+------------------------------------ ------------------------------------- ------- -------------------------------
+Guid_0000000000000000000000000000002 {id=dns-1, network_plan=test-project} {}      {vm-1.acme.test="198.51.100.0"}
+
+Forwarding_Group table
+_uuid child_port external_ids liveness name vip vmac
+----- ---------- ------------ -------- ---- --- ----
+
+Gateway_Chassis table
+_uuid chassis_name external_ids name options priority
+----- ------------ ------------ ---- ------- --------
+
+HA_Chassis table
+_uuid chassis_name external_ids priority
+----- ------------ ------------ --------
+
+HA_Chassis_Group table
+_uuid external_ids ha_chassis name
+----- ------------ ---------- ----
+
+Load_Balancer table
+_uuid external_ids health_check ip_port_mappings name options protocol selection_fields vips
+----- ------------ ------------ ---------------- ---- ------- -------- ---------------- ----
+
+Load_Balancer_Group table
+_uuid load_balancer name
+----- ------------- ----
+
+Load_Balancer_Health_Check table
+_uuid external_ids options vip
+----- ------------ ------- ---
+
+Logical_Router table
+_uuid                                copp enabled external_ids                load_balancer load_balancer_group name     nat                                                                          options policies ports                                                                        static_routes
+------------------------------------ ---- ------- --------------------------- ------------- ------------------- -------- ---------------------------------------------------------------------------- ------- -------- ---------------------------------------------------------------------------- --------------------------------------
+Guid_0000000000000000000000000000003 []   []      {network_plan=test-project} []            []                  router-1 [Guid_0000000000000000000000000000004, Guid_0000000000000000000000000000005] {}      []       [Guid_0000000000000000000000000000006, Guid_0000000000000000000000000000007] [Guid_0000000000000000000000000000008]
+
+Logical_Router_Policy table
+_uuid action bfd_sessions chain external_ids jump_chain match nexthop nexthops options output_port priority
+----- ------ ------------ ----- ------------ ---------- ----- ------- -------- ------- ----------- --------
+
+Logical_Router_Port table
+_uuid                                dhcp_relay enabled external_ids                                     gateway_chassis ha_chassis_group ipv6_prefix ipv6_ra_configs mac                 name                          networks            options peer status
+------------------------------------ ---------- ------- ------------------------------------------------ --------------- ---------------- ----------- --------------- ------------------- ----------------------------- ------------------- ------- ---- ------
+Guid_0000000000000000000000000000007 []         []      {network_plan=test-project}                      []              []               []          {}              "02:00:00:00:00:02" RS-router-1-switch-1          ["198.51.100.1/24"] {}      []   {}
+Guid_0000000000000000000000000000006 []         []      {chassis_group=local, network_plan=test-project} []              []               []          {}              "02:00:00:00:00:01" RS-router-1-provider-switch-1 ["192.0.2.100/24"]  {}      []   {}
+
+Logical_Router_Static_Route table
+_uuid                                bfd external_ids                                      ip_prefix   nexthop     options output_port policy route_table selection_fields
+------------------------------------ --- ------------------------------------------------- ----------- ----------- ------- ----------- ------ ----------- ----------------
+Guid_0000000000000000000000000000008 []  {network_plan=test-project, router_name=router-1} "0.0.0.0/0" "198.0.2.1" {}      []          []     ""          []
+
+Logical_Switch table
+_uuid                                acls copp dns_records external_ids                                forwarding_groups load_balancer load_balancer_group name              other_config ports                                                                        qos_rules
+------------------------------------ ---- ---- ----------- ------------------------------------------- ----------------- ------------- ------------------- ----------------- ------------ ---------------------------------------------------------------------------- ---------
+Guid_0000000000000000000000000000009 []   []   []          {dns_records="", network_plan=test-project} []                []            []                  provider-switch-1 {}           [Guid_0000000000000000000000000000010, Guid_0000000000000000000000000000011] []
+Guid_0000000000000000000000000000012 []   []   []          {dns_records="", network_plan=test-project} []                []            []                  switch-1          {}           [Guid_0000000000000000000000000000013, Guid_0000000000000000000000000000014] []
+
+Logical_Switch_Port table
+_uuid                                addresses                            dhcpv4_options                       dhcpv6_options dynamic_addresses enabled external_ids                                        ha_chassis_group health_checks mirror_rules name                          options                                                           parent_name peer port_security                        tag tag_request type     up
+------------------------------------ ------------------------------------ ------------------------------------ -------------- ----------------- ------- --------------------------------------------------- ---------------- ------------- ------------ ----------------------------- ----------------------------------------------------------------- ----------- ---- ------------------------------------ --- ----------- -------- --
+Guid_0000000000000000000000000000014 ["02:01:00:00:00:01 198.51.100.100"] Guid_0000000000000000000000000000001 []             []                []      {dhcp_options_v4=dhcp-1, network_plan=test-project} []               []            []           switch-1-port-1               {}                                                                []          []   ["02:01:00:00:00:01 198.51.100.100"] []  []          ""       []
+Guid_0000000000000000000000000000011 [router]                             []                                   []             []                []      {network_plan=test-project}                         []               []            []           SR-provider-switch-1-router-1 {nat-addresses=router, router-port=RS-router-1-provider-switch-1} []          []   []                                   []  []          router   []
+Guid_0000000000000000000000000000013 [router]                             []                                   []             []                []      {network_plan=test-project}                         []               []            []           SR-switch-1-router-1          {nat-addresses=router, router-port=RS-router-1-switch-1}          []          []   []                                   []  []          router   []
+Guid_0000000000000000000000000000010 [unknown]                            []                                   []             []                []      {network_plan=test-project}                         []               []            []           SN-provider-switch-1-extern   {network_name=extern}                                             []          []   []                                   5   []          localnet []
+
+Logical_Switch_Port_Health_Check table
+_uuid address options port protocol src_ip status
+----- ------- ------- ---- -------- ------ ------
+
+Meter table
+_uuid bands external_ids fair name unit
+----- ----- ------------ ---- ---- ----
+
+Meter_Band table
+_uuid action burst_size external_ids rate
+----- ------ ---------- ------------ ----
+
+Mirror table
+_uuid external_ids filter index mirror_rules name sink type
+----- ------------ ------ ----- ------------ ---- ---- ----
+
+Mirror_Rule table
+_uuid action match priority
+----- ------ ----- --------
+
+NAT table
+_uuid                                allowed_ext_ips exempted_ext_ips external_ids                                      external_ip   external_mac        external_port_range gateway_port logical_ip        logical_port match options priority type
+------------------------------------ --------------- ---------------- ------------------------------------------------- ------------- ------------------- ------------------- ------------ ----------------- ------------ ----- ------- -------- -------------
+Guid_0000000000000000000000000000005 []              []               {network_plan=test-project, router_name=router-1} "192.0.2.100" []                  ""                  []           "198.51.100.0/24" []           ""    {}      0        snat
+Guid_0000000000000000000000000000004 []              []               {network_plan=test-project, router_name=router-1} "192.0.2.110" "02:00:00:00:00:03" ""                  []           "198.51.100.100"  []           ""    {}      0        dnat_and_snat
+
+NB_Global table
+_uuid                                connections external_ids hv_cfg hv_cfg_timestamp ipsec name nb_cfg nb_cfg_timestamp options sb_cfg sb_cfg_timestamp ssl
+------------------------------------ ----------- ------------ ------ ---------------- ----- ---- ------ ---------------- ------- ------ ---------------- ---
+Guid_0000000000000000000000000000015 []          {}           0      0                false ""   0      0                {}      0      0                []
+
+Network_Function table
+_uuid external_ids health_check id inport name outport
+----- ------------ ------------ -- ------ ---- -------
+
+Network_Function_Group table
+_uuid external_ids fallback id mode name network_function network_function_active
+----- ------------ -------- -- ---- ---- ---------------- -----------------------
+
+Network_Function_Health_Check table
+_uuid external_ids name options
+----- ------------ ---- -------
+
+Port_Group table
+_uuid acls external_ids name ports
+----- ---- ------------ ---- -----
+
+QoS table
+_uuid action bandwidth direction external_ids match priority
+----- ------ --------- --------- ------------ ----- --------
+
+SSL table
+_uuid bootstrap_ca_cert ca_cert certificate external_ids private_key ssl_ciphers ssl_ciphersuites ssl_protocols
+----- ----------------- ------- ----------- ------------ ----------- ----------- ---------------- -------------
+
+Sample table
+_uuid collectors metadata
+----- ---------- --------
+
+Sample_Collector table
+_uuid external_ids id name probability set_id
+----- ------------ -- ---- ----------- ------
+
+Sampling_App table
+_uuid external_ids id type
+----- ------------ -- ----
+
+Static_MAC_Binding table
+_uuid ip logical_port mac override_dynamic_mac
+----- -- ------------ --- --------------------

--- a/test/OVN.Core.IntegrationTests/NetworkPlanRealizerTests.ApplyNetworkPlan_UpdatedPlan_PlanIsApplied.verified.txt
+++ b/test/OVN.Core.IntegrationTests/NetworkPlanRealizerTests.ApplyNetworkPlan_UpdatedPlan_PlanIsApplied.verified.txt
@@ -1,6 +1,6 @@
 ﻿ACL table
-_uuid action direction external_ids label log match meter name options priority sample_est sample_new severity tier
------ ------ --------- ------------ ----- --- ----- ----- ---- ------- -------- ---------- ---------- -------- ----
+_uuid action direction external_ids label log match meter name network_function_group options priority sample_est sample_new severity tier
+----- ------ --------- ------------ ----- --- ----- ----- ---- ---------------------- ------- -------- ---------- ---------- -------- ----
 
 Address_Set table
 _uuid addresses external_ids name
@@ -70,8 +70,8 @@ _uuid                                copp enabled external_ids                lo
 Guid_0000000000000000000000000000003 []   []      {network_plan=test-project} []            []                  router-2 [Guid_0000000000000000000000000000004, Guid_0000000000000000000000000000005] {}      []       [Guid_0000000000000000000000000000006, Guid_0000000000000000000000000000007] [Guid_0000000000000000000000000000008]
 
 Logical_Router_Policy table
-_uuid action bfd_sessions chain external_ids jump_chain match nexthop nexthops options priority
------ ------ ------------ ----- ------------ ---------- ----- ------- -------- ------- --------
+_uuid action bfd_sessions chain external_ids jump_chain match nexthop nexthops options output_port priority
+----- ------ ------------ ----- ------------ ---------- ----- ------- -------- ------- ----------- --------
 
 Logical_Router_Port table
 _uuid                                dhcp_relay enabled external_ids                                     gateway_chassis ha_chassis_group ipv6_prefix ipv6_ra_configs mac                 name                          networks            options peer status
@@ -91,12 +91,16 @@ Guid_0000000000000000000000000000009 []   []   []          {dns_records="", netw
 Guid_0000000000000000000000000000012 []   []   []          {dns_records="", network_plan=test-project} []                []            []                  switch-2          {}           [Guid_0000000000000000000000000000013, Guid_0000000000000000000000000000014] []
 
 Logical_Switch_Port table
-_uuid                                addresses                            dhcpv4_options                       dhcpv6_options dynamic_addresses enabled external_ids                                        ha_chassis_group mirror_rules name                          options                                                           parent_name peer port_security                        tag tag_request type     up
------------------------------------- ------------------------------------ ------------------------------------ -------------- ----------------- ------- --------------------------------------------------- ---------------- ------------ ----------------------------- ----------------------------------------------------------------- ----------- ---- ------------------------------------ --- ----------- -------- --
-Guid_0000000000000000000000000000014 ["02:01:00:00:00:01 198.51.100.100"] Guid_0000000000000000000000000000001 []             []                []      {dhcp_options_v4=dhcp-2, network_plan=test-project} []               []           switch2-port-1                {}                                                                []          []   ["02:01:00:00:00:01 198.51.100.100"] []  []          ""       []
-Guid_0000000000000000000000000000011 [router]                             []                                   []             []                []      {network_plan=test-project}                         []               []           SR-provider-switch-2-router-2 {nat-addresses=router, router-port=RS-router-2-provider-switch-2} []          []   []                                   []  []          router   []
-Guid_0000000000000000000000000000013 [router]                             []                                   []             []                []      {network_plan=test-project}                         []               []           SR-switch-2-router-2          {nat-addresses=router, router-port=RS-router-2-switch-2}          []          []   []                                   []  []          router   []
-Guid_0000000000000000000000000000010 [unknown]                            []                                   []             []                []      {network_plan=test-project}                         []               []           SN-provider-switch-2-extern   {network_name=extern}                                             []          []   []                                   5   []          localnet []
+_uuid                                addresses                            dhcpv4_options                       dhcpv6_options dynamic_addresses enabled external_ids                                        ha_chassis_group health_checks mirror_rules name                          options                                                           parent_name peer port_security                        tag tag_request type     up
+------------------------------------ ------------------------------------ ------------------------------------ -------------- ----------------- ------- --------------------------------------------------- ---------------- ------------- ------------ ----------------------------- ----------------------------------------------------------------- ----------- ---- ------------------------------------ --- ----------- -------- --
+Guid_0000000000000000000000000000014 ["02:01:00:00:00:01 198.51.100.100"] Guid_0000000000000000000000000000001 []             []                []      {dhcp_options_v4=dhcp-2, network_plan=test-project} []               []            []           switch2-port-1                {}                                                                []          []   ["02:01:00:00:00:01 198.51.100.100"] []  []          ""       []
+Guid_0000000000000000000000000000011 [router]                             []                                   []             []                []      {network_plan=test-project}                         []               []            []           SR-provider-switch-2-router-2 {nat-addresses=router, router-port=RS-router-2-provider-switch-2} []          []   []                                   []  []          router   []
+Guid_0000000000000000000000000000013 [router]                             []                                   []             []                []      {network_plan=test-project}                         []               []            []           SR-switch-2-router-2          {nat-addresses=router, router-port=RS-router-2-switch-2}          []          []   []                                   []  []          router   []
+Guid_0000000000000000000000000000010 [unknown]                            []                                   []             []                []      {network_plan=test-project}                         []               []            []           SN-provider-switch-2-extern   {network_name=extern}                                             []          []   []                                   5   []          localnet []
+
+Logical_Switch_Port_Health_Check table
+_uuid address options port protocol src_ip status
+----- ------- ------- ---- -------- ------ ------
 
 Meter table
 _uuid bands external_ids fair name unit
@@ -107,8 +111,12 @@ _uuid action burst_size external_ids rate
 ----- ------ ---------- ------------ ----
 
 Mirror table
-_uuid external_ids filter index name sink type
------ ------------ ------ ----- ---- ---- ----
+_uuid external_ids filter index mirror_rules name sink type
+----- ------------ ------ ----- ------------ ---- ---- ----
+
+Mirror_Rule table
+_uuid action match priority
+----- ------ ----- --------
 
 NAT table
 _uuid                                allowed_ext_ips exempted_ext_ips external_ids                                      external_ip   external_mac        external_port_range gateway_port logical_ip        logical_port match options priority type
@@ -120,6 +128,18 @@ NB_Global table
 _uuid                                connections external_ids hv_cfg hv_cfg_timestamp ipsec name nb_cfg nb_cfg_timestamp options sb_cfg sb_cfg_timestamp ssl
 ------------------------------------ ----------- ------------ ------ ---------------- ----- ---- ------ ---------------- ------- ------ ---------------- ---
 Guid_0000000000000000000000000000015 []          {}           0      0                false ""   0      0                {}      0      0                []
+
+Network_Function table
+_uuid external_ids health_check id inport name outport
+----- ------------ ------------ -- ------ ---- -------
+
+Network_Function_Group table
+_uuid external_ids fallback id mode name network_function network_function_active
+----- ------------ -------- -- ---- ---- ---------------- -----------------------
+
+Network_Function_Health_Check table
+_uuid external_ids name options
+----- ------------ ---- -------
 
 Port_Group table
 _uuid acls external_ids name ports

--- a/test/OVN.Core.IntegrationTests/NetworkPlanRealizerTests.ApplyNetworkPlan_UpdatedPlan_PlanIsApplied.verified.txt
+++ b/test/OVN.Core.IntegrationTests/NetworkPlanRealizerTests.ApplyNetworkPlan_UpdatedPlan_PlanIsApplied.verified.txt
@@ -114,7 +114,7 @@ NAT table
 _uuid                                allowed_ext_ips exempted_ext_ips external_ids                                      external_ip   external_mac        external_port_range gateway_port logical_ip        logical_port match options priority type
 ------------------------------------ --------------- ---------------- ------------------------------------------------- ------------- ------------------- ------------------- ------------ ----------------- ------------ ----- ------- -------- -------------
 Guid_0000000000000000000000000000005 []              []               {network_plan=test-project, router_name=router-2} "192.0.2.100" []                  ""                  []           "198.51.100.0/24" []           ""    {}      0        snat
-Guid_0000000000000000000000000000004 []              []               {network_plan=test-project, router_name=router-2} "192.0.2.110" "02:00:00:00:00:03" ""                  []           "198.51.100.100"  ""           ""    {}      0        dnat_and_snat
+Guid_0000000000000000000000000000004 []              []               {network_plan=test-project, router_name=router-2} "192.0.2.110" "02:00:00:00:00:03" ""                  []           "198.51.100.100"  []           ""    {}      0        dnat_and_snat
 
 NB_Global table
 _uuid                                connections external_ids hv_cfg hv_cfg_timestamp ipsec name nb_cfg nb_cfg_timestamp options sb_cfg sb_cfg_timestamp ssl

--- a/test/OVN.Core.IntegrationTests/NetworkPlanRealizerTests.cs
+++ b/test/OVN.Core.IntegrationTests/NetworkPlanRealizerTests.cs
@@ -78,6 +78,16 @@ public class NetworkPlanRealizerTests(
     }
 
     [Fact]
+    public async Task ApplyNetworkPlan_SamePlanTwice_NoClearOnRequiredColumns()
+    {
+        var plan = CreateNetworkPlan();
+        await ApplyNetworkPlan(plan);
+        await ApplyNetworkPlan(plan);
+
+        await VerifyDatabase();
+    }
+
+    [Fact]
     public async Task ApplyNetworkPlan_RemoveChildResources_PlanIsApplied()
     {
         await ApplyNetworkPlan(CreateNetworkPlan());

--- a/test/OVN.Core.IntegrationTests/OvnControlToolTestBase.cs
+++ b/test/OVN.Core.IntegrationTests/OvnControlToolTestBase.cs
@@ -24,6 +24,6 @@ public abstract class OvnControlToolTestBase : OvsDbTestBase
 
     protected async Task VerifyDatabase()
     {
-        await VerifyDatabase("OVN_Northbound", "7.11.0");
+        await VerifyDatabase("OVN_Northbound", "7.18.0");
     }
 }

--- a/test/OVN.Core.IntegrationTests/OvnSouthboundControlToolTestBase.cs
+++ b/test/OVN.Core.IntegrationTests/OvnSouthboundControlToolTestBase.cs
@@ -28,6 +28,6 @@ public class OvnSouthboundControlToolTestBase : OvsDbTestBase
 
     protected async Task VerifyDatabase()
     {
-        await VerifyDatabase("OVN_Southbound", "20.41.0");
+        await VerifyDatabase("OVN_Southbound", "21.8.0");
     }
 }


### PR DESCRIPTION
Brings the library up to OVN 26.03 / OVS 3.7.0.

- **DNAT fix.** OVN 25.03 (`ac0adb50f`) now rejects empty-string `NAT.external_mac` and drops the entire NAT entry. `PlannedNATRule` normalises blank `ExternalMAC` / `LogicalPort` to `null` so they are emitted as OVSDB unset, and `NetworkPlanParser.ParseRouterNAT` drops the empty-string sentinels for the same fields.
- **Schema bump.** Integration test bases now expect NB 7.18.0 and SB 21.8.0 (OVS stays at 8.8.0).
- **Snapshot regen.** All 8 NetworkPlan/ClusterPlan verified snapshots re-recorded against 26.03 (new tables Mirror_Rule / Network_Function* / Logical_Switch_Port_Health_Check / Static_MAC_Binding / Sample*; new columns ACL.network_function_group, Logical_Router_Policy.output_port, Logical_Switch_Port.health_checks, Mirror.mirror_rules).
- **README.** Document the integration-test setup, including the `pthreadVC3.dll` must-be-in-both-`bin/`-and-`sbin/` trap (otherwise `ovsdb-server.exe` / `ovs-vswitchd.exe` exit with `STATUS_DLL_NOT_FOUND` and the tests hang in `WaitForDbSocket`).

All 13 integration tests pass against OVN 26.03.1 / OVS 3.7.0; 32 unit tests pass; full solution builds clean.