### PR TITLE
Bump NuGet dependencies

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -32,10 +32,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
+    <PackageReference Include="GitVersion.MsBuild" Version="6.7.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.204" PrivateAssets="All"/>
   </ItemGroup>
 </Project>

--- a/src/OVN.Core/OVN.Core.csproj
+++ b/src/OVN.Core/OVN.Core.csproj
@@ -13,7 +13,7 @@
 
     <ItemGroup>
       <PackageReference Include="LanguageExt.Core" Version="4.4.9" />
-      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
       <PackageReference Include="System.Management" Version="8.0.0" />
       <PackageReference Include="System.ServiceProcess.ServiceController" Version="8.0.1" />
     </ItemGroup>

--- a/src/OVN.Hosting/OVN.Hosting.csproj
+++ b/src/OVN.Hosting/OVN.Hosting.csproj
@@ -10,7 +10,7 @@
     <ItemGroup>
         <PackageReference Include="LanguageExt.Core" Version="4.4.9" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
         <PackageReference Include="System.Management" Version="8.0.0" />
         <PackageReference Include="System.ServiceProcess.ServiceController" Version="8.0.1" />
     </ItemGroup>

--- a/src/OVN.Primitives/OVN.Primitives.csproj
+++ b/src/OVN.Primitives/OVN.Primitives.csproj
@@ -8,8 +8,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="IPNetwork2" Version="3.0.667" />
-        <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
+        <PackageReference Include="IPNetwork2" Version="4.3.0" />
+        <PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
         <PackageReference Include="LanguageExt.Core" Version="4.4.9" />
     </ItemGroup>
 

--- a/src/OVNAgent/OVNAgent.csproj
+++ b/src/OVNAgent/OVNAgent.csproj
@@ -14,11 +14,11 @@
         <PackageReference Include="LanguageExt.Core" Version="4.4.9" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
         <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="8.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
         <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
         <PackageReference Include="System.Management" Version="8.0.0" />
         <PackageReference Include="System.ServiceProcess.ServiceController" Version="8.0.1" />
-        <PackageReference Include="YamlDotNet" Version="16.2.0" />
+        <PackageReference Include="YamlDotNet" Version="18.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/OVN.Core.IntegrationTests/OVN.Core.IntegrationTests.csproj
+++ b/test/OVN.Core.IntegrationTests/OVN.Core.IntegrationTests.csproj
@@ -9,15 +9,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AwesomeAssertions" Version="9.3.0" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="IdGen" Version="3.0.7" />
-    <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.6.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
-    <PackageReference Include="Verify.Xunit" Version="31.4.3" />
+    <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Verify.Xunit" Version="31.12.5" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/test/OVN.Core.Tests/OVN.Core.Tests.csproj
+++ b/test/OVN.Core.Tests/OVN.Core.Tests.csproj
@@ -10,8 +10,8 @@
 
     <ItemGroup>
         <PackageReference Include="LanguageExt.Core" Version="4.4.9" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
         <PackageReference Include="System.Management" Version="8.0.0" />
         <PackageReference Include="System.ServiceProcess.ServiceController" Version="8.0.1" />
         <PackageReference Include="xunit" Version="2.9.3" />
@@ -19,7 +19,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
+        <PackageReference Include="coverlet.collector" Version="10.0.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/test/OVN.Primitives.Tests/OVN.Primitives.Tests.csproj
+++ b/test/OVN.Primitives.Tests/OVN.Primitives.Tests.csproj
@@ -10,8 +10,8 @@
 
     <ItemGroup>
         <PackageReference Include="LanguageExt.Core" Version="4.4.9" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
         <PackageReference Include="System.Management" Version="8.0.0" />
         <PackageReference Include="System.ServiceProcess.ServiceController" Version="8.0.1" />
         <PackageReference Include="xunit" Version="2.9.3" />
@@ -19,7 +19,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
+        <PackageReference Include="coverlet.collector" Version="10.0.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/test/OVN.TestTools/OVN.TestTools.csproj
+++ b/test/OVN.TestTools/OVN.TestTools.csproj
@@ -9,9 +9,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="CompareNETObjects" Version="4.83.0" />
+        <PackageReference Include="CompareNETObjects" Version="4.84.0" />
         <PackageReference Include="LanguageExt.Core" Version="4.4.9" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="System.Management" Version="8.0.0" />
         <PackageReference Include="System.ServiceProcess.ServiceController" Version="8.0.1" />

--- a/test/OVNAgent.Tests/OVNAgent.Tests.csproj
+++ b/test/OVNAgent.Tests/OVNAgent.Tests.csproj
@@ -10,12 +10,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AwesomeAssertions" Version="9.3.0" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Updates NuGet packages across `src/` and `test/`. .NET runtime packages stay on the 8.x line; other packages move to the latest stable.

**8.x runtime packages**
- Microsoft.Extensions.Logging.Abstractions 8.0.2 -> 8.0.3
- (Hosting/Hosting.WindowsServices/ServiceController/System.Management already at the latest 8.0.x)

**Other packages**
- IPNetwork2 3.0.667 -> 4.3.0
- JetBrains.Annotations 2024.3.0 -> 2025.2.4
- Microsoft.SourceLink.GitHub 8.0.0 -> 10.0.204
- GitVersion.MsBuild 5.11.1 -> 6.7.0
- YamlDotNet 16.2.0 -> 18.0.0
- Microsoft.NET.Test.Sdk 18.0.0 -> 18.6.0
- AwesomeAssertions 9.3.0 -> 9.4.0
- Verify.Xunit 31.4.3 -> 31.12.5
- CompareNETObjects 4.83.0 -> 4.84.0
- MartinCostello.Logging.XUnit 0.6.0 -> 0.7.1
- coverlet.collector 6.0.4 -> 10.0.1

Builds clean and all unit tests pass (44/44 across OVN.Primitives.Tests, OVN.Core.Tests, OVNAgent.Tests). Integration tests not run locally (require live OVN).

Supersedes / replaces:
- #39 GitVersion.MsBuild (we go higher to 6.7.0)
- #40 YamlDotNet (we go higher to 18.0.0)
- #43 xunit (already at 2.9.3 on main)
- #42 Microsoft.Extensions.* 9.x — closing, staying on 8.x
- #44 System.Management 9.x — closing, staying on 8.x