### PR TITLE
Add northbound remote listener and SSL support to the cluster plan

### DIFF
--- a/src/OVN.Core/ClusterPlan.cs
+++ b/src/OVN.Core/ClusterPlan.cs
@@ -5,11 +5,15 @@ namespace Dbosoft.OVN;
 
 public record ClusterPlan
 {
+    public PlannedNorthboundSsl? PlannedNorthboundSsl { get; init; }
+
     public PlannedSouthboundSsl? PlannedSouthboundSsl { get; init; }
 
     public HashMap<string, PlannedChassisGroup> PlannedChassisGroups { get; init; }
 
     public HashMap<string, PlannedChassis> PlannedChassis { get; init; }
+
+    public HashMap<string, PlannedNorthboundConnection> PlannedNorthboundConnections { get; init; }
 
     public HashMap<string, PlannedSouthboundConnection> PlannedSouthboundConnections { get; init; }
 }

--- a/src/OVN.Core/ClusterPlanConfigurationExtensions.cs
+++ b/src/OVN.Core/ClusterPlanConfigurationExtensions.cs
@@ -34,6 +34,40 @@ public static class ClusterPlanConfigurationExtensions
         };
     }
 
+    public static ClusterPlan AddNorthboundConnection(
+        this ClusterPlan plan,
+        int port = 6641,
+        bool ssl = false,
+        IPAddress? ipAddress = null)
+    {
+        var protocol = ssl ? "pssl" : "ptcp";
+        var target = ipAddress is null ? $"{protocol}:{port}" : $"{protocol}:{port}:{ipAddress}";
+        return plan with
+        {
+            PlannedNorthboundConnections = plan.PlannedNorthboundConnections.Add(
+                target,
+                new PlannedNorthboundConnection { Target = target }),
+        };
+    }
+
+    public static ClusterPlan SetNorthboundSsl(
+        this ClusterPlan plan,
+        string privateKey,
+        string certificate,
+        string caCertificate)
+    {
+        return plan with
+        {
+            PlannedNorthboundSsl = new PlannedNorthboundSsl
+            {
+                PrivateKey = privateKey,
+                Certificate = certificate,
+                CaCertificate = caCertificate,
+                SslProtocols = "TLSv1.3,TLSv1.2",
+            }
+        };
+    }
+
     public static ClusterPlan AddSouthboundConnection(
         this ClusterPlan plan,
         int port = 6642,

--- a/src/OVN.Core/ClusterPlanNorthboundRealizer.cs
+++ b/src/OVN.Core/ClusterPlanNorthboundRealizer.cs
@@ -2,6 +2,8 @@
 using LanguageExt;
 using LanguageExt.Common;
 
+using static LanguageExt.Prelude;
+
 namespace Dbosoft.OVN;
 
 public class ClusterPlanNorthboundRealizer(
@@ -51,5 +53,39 @@ public class ClusterPlanNorthboundRealizer(
             remainingChassis,
             existingPlannedChassis,
             cancellationToken: cancellationToken)
+        from _3 in ApplyNorthboundConnections(clusterPlan, cancellationToken)
+        from _4 in ApplySsl<PlannedNorthboundSsl, NorthboundSsl, NorthboundGlobal>(
+            clusterPlan.PlannedNorthboundSsl,
+            OVNTableNames.Global,
+            cancellationToken)
         select clusterPlan;
+
+    private EitherAsync<Error, Unit> ApplyNorthboundConnections(
+        ClusterPlan clusterPlan,
+        CancellationToken cancellationToken) =>
+        from global in FindRecords<NorthboundGlobal>(
+            OVNTableNames.Global,
+            NorthboundGlobal.Columns,
+            cancellationToken: cancellationToken)
+        from existingConnection in FindRecordsWithParents<NorthboundConnection, NorthboundGlobal>(
+            OVNTableNames.Connection,
+            global.Values.ToSeq(),
+            NorthboundConnection.Columns,
+            cancellationToken: cancellationToken)
+        from remainingConnections in RemoveEntitiesNotPlanned(
+            OVNTableNames.Connection,
+            existingConnection,
+            clusterPlan.PlannedNorthboundConnections,
+            cancellationToken: cancellationToken)
+        from existingPlannedConnections in CreatePlannedEntities(
+            OVNTableNames.Connection,
+            remainingConnections,
+            clusterPlan.PlannedNorthboundConnections,
+            cancellationToken: cancellationToken)
+        from _1 in UpdateEntities(
+            OVNTableNames.Connection,
+            remainingConnections,
+            existingPlannedConnections,
+            cancellationToken: cancellationToken)
+        select unit;
 }

--- a/src/OVN.Core/Nodes/NetworkControllerNode.cs
+++ b/src/OVN.Core/Nodes/NetworkControllerNode.cs
@@ -37,7 +37,12 @@ public class NetworkControllerNode : DemonNodeBase
                 .WithDbConnection(_ovnSettings.NorthDBConnection)
                 .WithLogging(_ovnSettings.Logging)
                 .AllowAttach(false)
-                .UseRemoteConfigsFromDatabase(false)
+                // Read remote listeners and SSL from the NB_Global connections/ssl
+                // tables (like the southbound DB) so a cluster plan can expose the
+                // northbound DB to remote clients over SSL. With no planned
+                // connections this only adds the local pipe remote, so in-process
+                // deployments are unaffected.
+                .UseRemoteConfigsFromDatabase(true)
                 .Build(),
             _loggerFactory.CreateLogger<OVSDBProcess>());
 

--- a/src/OVN.Primitives/Model/OVN/NorthboundConnection.cs
+++ b/src/OVN.Primitives/Model/OVN/NorthboundConnection.cs
@@ -1,0 +1,24 @@
+using static LanguageExt.Prelude;
+
+namespace Dbosoft.OVN.Model.OVN;
+
+public record NorthboundConnection : OVSTableRecord, IHasParentReference, IOVSEntityWithName
+{
+    public new static readonly IDictionary<string, OVSFieldMetadata>
+        Columns = new Dictionary<string, OVSFieldMetadata>(OVSTableRecord.Columns)
+        {
+            { "target", OVSValue<string>.Metadata() },
+        };
+
+    public string? Target => GetValue<string>("target");
+
+    public string? Name => Target;
+
+    public OVSParentReference GetParentReference()
+    {
+        return new OVSParentReference(
+            OVNTableNames.Global,
+            Optional(GetValue<Guid>("__parentId")).Map(i => i.ToString("D")),
+            "Connections");
+    }
+}

--- a/src/OVN.Primitives/Model/OVN/NorthboundGlobal.cs
+++ b/src/OVN.Primitives/Model/OVN/NorthboundGlobal.cs
@@ -1,0 +1,20 @@
+using LanguageExt;
+
+namespace Dbosoft.OVN.Model.OVN;
+
+public record NorthboundGlobal : OVSGlobalTableRecord, IOVSEntityWithName, IHasOVSReferences<NorthboundConnection>, IHasOVSReferences<NorthboundSsl>
+{
+    public new static readonly IDictionary<string, OVSFieldMetadata>
+        Columns = new Dictionary<string, OVSFieldMetadata>(OVSGlobalTableRecord.Columns)
+        {
+            { "connections", OVSReference.Metadata() },
+        };
+
+    public Seq<Guid> Connections => GetReference("connections");
+
+    public string? Name => ".";
+
+    Seq<Guid> IHasOVSReferences<NorthboundConnection>.GetOvsReferences() => Connections;
+
+    Seq<Guid> IHasOVSReferences<NorthboundSsl>.GetOvsReferences() => Ssl;
+}

--- a/src/OVN.Primitives/Model/OVN/NorthboundSsl.cs
+++ b/src/OVN.Primitives/Model/OVN/NorthboundSsl.cs
@@ -1,0 +1,31 @@
+using static LanguageExt.Prelude;
+
+namespace Dbosoft.OVN.Model.OVN;
+
+public record NorthboundSsl : OVSSslTableRecord
+{
+    public new static readonly IDictionary<string, OVSFieldMetadata>
+        Columns = new Dictionary<string, OVSFieldMetadata>(OVSSslTableRecord.Columns)
+        {
+            { "ssl_protocols", OVSValue<string>.Metadata() },
+            { "ssl_ciphers", OVSValue<string>.Metadata() },
+            { "ssl_ciphersuites", OVSValue<string>.Metadata() },
+        };
+
+    // The SSL settings (protocols, ciphers, etc.) are intentionally defined
+    // here as these settings are missing in the Open vSwitch database schema.
+
+    public string? SslProtocols => GetValue<string>("ssl_protocols");
+
+    public string? SslCiphers => GetValue<string>("ssl_ciphers");
+
+    public string? SslCipherSuites => GetValue<string>("ssl_ciphersuites");
+
+    public override OVSParentReference GetParentReference()
+    {
+        return new OVSParentReference(
+            OVNTableNames.Global,
+            Optional(GetValue<Guid>("__parentId")).Map(i => i.ToString("D")),
+            "ssl");
+    }
+}

--- a/src/OVN.Primitives/Model/OVN/NorthboundSsl.cs
+++ b/src/OVN.Primitives/Model/OVN/NorthboundSsl.cs
@@ -12,8 +12,9 @@ public record NorthboundSsl : OVSSslTableRecord
             { "ssl_ciphersuites", OVSValue<string>.Metadata() },
         };
 
-    // The SSL settings (protocols, ciphers, etc.) are intentionally defined
-    // here as these settings are missing in the Open vSwitch database schema.
+    // ssl_protocols/ssl_ciphers/ssl_ciphersuites exist in the OVN SSL table but
+    // not in the Open_vSwitch (switch) SSL schema, so they are declared here in
+    // the OVN-specific record instead of the shared OVSSslTableRecord.
 
     public string? SslProtocols => GetValue<string>("ssl_protocols");
 

--- a/src/OVN.Primitives/Model/OVN/OVNTableNames.cs
+++ b/src/OVN.Primitives/Model/OVN/OVNTableNames.cs
@@ -13,4 +13,6 @@ public static class OVNTableNames
     public const string DnsRecords = "dns";
     public const string ChassisGroups = "ha_chassis_group";
     public const string Chassis = "ha_chassis";
+    public const string Connection = "Connection";
+    public const string Ssl = "SSL";
 }

--- a/src/OVN.Primitives/Model/OVN/PlannedNorthboundConnection.cs
+++ b/src/OVN.Primitives/Model/OVN/PlannedNorthboundConnection.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+
+namespace Dbosoft.OVN.Model.OVN;
+
+public record PlannedNorthboundConnection : OVSEntity, IHasParentReference, IOVSEntityWithName
+{
+    public new static readonly IDictionary<string, OVSFieldMetadata>
+        Columns = new Dictionary<string, OVSFieldMetadata>(OVSEntity.Columns)
+        {
+            { "target", OVSValue<string>.Metadata() }
+        };
+
+    public string? Target
+    {
+        get => GetValue<string>("target");
+        init => SetValue("target", value);
+    }
+
+    public string? Name => Target;
+
+    public OVSParentReference GetParentReference()
+    {
+        return new OVSParentReference(OVNTableNames.Global, ".", "connections");
+    }
+}

--- a/src/OVN.Primitives/Model/OVN/PlannedNorthboundSsl.cs
+++ b/src/OVN.Primitives/Model/OVN/PlannedNorthboundSsl.cs
@@ -1,0 +1,35 @@
+namespace Dbosoft.OVN.Model.OVN;
+
+public record PlannedNorthboundSsl : PlannedOvsSsl
+{
+    public new static readonly IDictionary<string, OVSFieldMetadata>
+        Columns = new Dictionary<string, OVSFieldMetadata>(PlannedOvsSsl.Columns)
+        {
+            { "private_key", OVSValue<string>.Metadata() },
+            { "certificate", OVSValue<string>.Metadata() },
+            { "ca_cert", OVSValue<string>.Metadata() },
+        };
+
+    public string? SslProtocols
+    {
+        get => GetValue<string>("ssl_protocols");
+        init => SetValue("ssl_protocols", value);
+    }
+
+    public string? SslCiphers
+    {
+        get => GetValue<string>("ssl_ciphers");
+        init => SetValue("ssl_ciphers", value);
+    }
+
+    public string? SslCipherSuites
+    {
+        get => GetValue<string>("ssl_ciphersuites");
+        init => SetValue("ssl_ciphersuites", value);
+    }
+
+    public override OVSParentReference GetParentReference()
+    {
+        return new OVSParentReference(OVNTableNames.Global, ".", "ssl");
+    }
+}

--- a/src/OVN.Primitives/Model/OVN/PlannedNorthboundSsl.cs
+++ b/src/OVN.Primitives/Model/OVN/PlannedNorthboundSsl.cs
@@ -5,9 +5,9 @@ public record PlannedNorthboundSsl : PlannedOvsSsl
     public new static readonly IDictionary<string, OVSFieldMetadata>
         Columns = new Dictionary<string, OVSFieldMetadata>(PlannedOvsSsl.Columns)
         {
-            { "private_key", OVSValue<string>.Metadata() },
-            { "certificate", OVSValue<string>.Metadata() },
-            { "ca_cert", OVSValue<string>.Metadata() },
+            { "ssl_protocols", OVSValue<string>.Metadata() },
+            { "ssl_ciphers", OVSValue<string>.Metadata() },
+            { "ssl_ciphersuites", OVSValue<string>.Metadata() },
         };
 
     public string? SslProtocols

--- a/src/OVN.Primitives/Model/OVN/PlannedSouthboundSsl.cs
+++ b/src/OVN.Primitives/Model/OVN/PlannedSouthboundSsl.cs
@@ -5,9 +5,9 @@ public record PlannedSouthboundSsl : PlannedOvsSsl
     public new static readonly IDictionary<string, OVSFieldMetadata>
         Columns = new Dictionary<string, OVSFieldMetadata>(PlannedOvsSsl.Columns)
         {
-            { "private_key", OVSValue<string>.Metadata() },
-            { "certificate", OVSValue<string>.Metadata() },
-            { "ca_cert", OVSValue<string>.Metadata() },
+            { "ssl_protocols", OVSValue<string>.Metadata() },
+            { "ssl_ciphers", OVSValue<string>.Metadata() },
+            { "ssl_ciphersuites", OVSValue<string>.Metadata() },
         };
 
     public string? SslProtocols

--- a/src/OVN.Primitives/Model/OVN/SouthboundSsl.cs
+++ b/src/OVN.Primitives/Model/OVN/SouthboundSsl.cs
@@ -12,8 +12,9 @@ public record SouthboundSsl : OVSSslTableRecord
             { "ssl_ciphersuites", OVSValue<string>.Metadata() },
         };
 
-    // The SSL settings (protocols, ciphers, etc.) are intentionally defined
-    // here as these settings are missing in the Open vSwitch database schema.
+    // ssl_protocols/ssl_ciphers/ssl_ciphersuites exist in the OVN SSL table but
+    // not in the Open_vSwitch (switch) SSL schema, so they are declared here in
+    // the OVN-specific record instead of the shared OVSSslTableRecord.
 
     public string? SslProtocols => GetValue<string>("ssl_protocols");
 

--- a/src/OVNAgent/ClusterPlanConfig.cs
+++ b/src/OVNAgent/ClusterPlanConfig.cs
@@ -4,6 +4,10 @@ public class ClusterPlanConfig
 {
     public IList<ChassisGroupConfig> ChassisGroups { get; set; } = new List<ChassisGroupConfig>();
 
+    public IList<NorthboundEndpointConfig> NorthboundEndpoints { get; set; } = new List<NorthboundEndpointConfig>();
+
+    public NorthboundSslConfig? NorthboundSsl { get; init; }
+
     public IList<SouthboundEndpointConfig> SouthboundEndpoints { get; set; } = new List<SouthboundEndpointConfig>();
 
     public SouthboundSslConfig? SouthboundSsl { get; init; }
@@ -21,6 +25,24 @@ public class ChassisConfig
     public required string Name { get; init; }
 
     public short? Priority { get; init; }
+}
+
+public class NorthboundEndpointConfig
+{
+    public required int Port { get; init; }
+
+    public bool? Ssl { get; init; }
+
+    public string? IpAddress { get; init; }
+}
+
+public class NorthboundSslConfig
+{
+    public required string PrivateKey { get; init; }
+
+    public required string Certificate { get; init; }
+
+    public required string CaCertificate { get; init; }
 }
 
 public class SouthboundEndpointConfig

--- a/src/OVNAgent/ClusterPlanParser.cs
+++ b/src/OVNAgent/ClusterPlanParser.cs
@@ -15,6 +15,13 @@ public static class ClusterPlanParser
             clusterPlan = ParseChassisGroup(clusterPlan, chassisGroupConfig);
         }
 
+        foreach (var northboundConnectionConfig in planConfig.NorthboundEndpoints)
+        {
+            clusterPlan = ParseNorthboundConnections(clusterPlan, northboundConnectionConfig);
+        }
+
+        clusterPlan = ParseNorthboundSsl(clusterPlan, planConfig.NorthboundSsl);
+
         foreach (var southboundConnectionConfig in planConfig.SouthboundEndpoints)
         {
             clusterPlan = ParseSouthboundConnections(clusterPlan, southboundConnectionConfig);
@@ -55,6 +62,30 @@ public static class ClusterPlanParser
             chassisConfig.Name,
             // The priority can be between 0 and 32,767. We use 16,383 as the default priority.
             chassisConfig.Priority.GetValueOrDefault(16383));
+    }
+
+    private static ClusterPlan ParseNorthboundConnections(
+        ClusterPlan clusterPlan,
+        NorthboundEndpointConfig endpointConfig)
+    {
+        return clusterPlan.AddNorthboundConnection(
+            endpointConfig.Port,
+            endpointConfig.Ssl.GetValueOrDefault(),
+            string.IsNullOrWhiteSpace(endpointConfig.IpAddress)
+                ? null
+                : IPAddress.Parse(endpointConfig.IpAddress));
+    }
+
+    private static ClusterPlan ParseNorthboundSsl(
+        ClusterPlan clusterPlan,
+        NorthboundSslConfig? sslConfig)
+    {
+        return sslConfig is null
+            ? clusterPlan
+            : clusterPlan.SetNorthboundSsl(
+                sslConfig.PrivateKey,
+                sslConfig.Certificate,
+                sslConfig.CaCertificate);
     }
 
     private static ClusterPlan ParseSouthboundConnections(

--- a/test/OVN.Core.IntegrationTests/ClusterPlanNorthboundConnectionRealizerTests.ApplyClusterPlan_NewPlan_IsSuccessful.verified.txt
+++ b/test/OVN.Core.IntegrationTests/ClusterPlanNorthboundConnectionRealizerTests.ApplyClusterPlan_NewPlan_IsSuccessful.verified.txt
@@ -1,0 +1,159 @@
+﻿ACL table
+_uuid action direction external_ids label log match meter name network_function_group options priority sample_est sample_new severity tier
+----- ------ --------- ------------ ----- --- ----- ----- ---- ---------------------- ------- -------- ---------- ---------- -------- ----
+
+Address_Set table
+_uuid addresses external_ids name
+----- --------- ------------ ----
+
+BFD table
+_uuid detect_mult dst_ip external_ids logical_port min_rx min_tx options status
+----- ----------- ------ ------------ ------------ ------ ------ ------- ------
+
+Chassis_Template_Var table
+_uuid chassis external_ids variables
+----- ------- ------------ ---------
+
+Connection table
+_uuid                                external_ids inactivity_probe is_connected max_backoff other_config status                                                                target
+------------------------------------ ------------ ---------------- ------------ ----------- ------------ --------------------------------------------------------------------- ----------------------
+Guid_0000000000000000000000000000001 {}           []               false        []          {}           {bound_port="41641", sec_since_connect="0", sec_since_disconnect="0"} "ptcp:41641:127.0.0.1"
+Guid_0000000000000000000000000000002 {}           []               false        []          {}           {bound_port="41642", sec_since_connect="0", sec_since_disconnect="0"} "pssl:41642:127.0.0.1"
+
+Copp table
+_uuid external_ids meters name
+----- ------------ ------ ----
+
+DHCP_Options table
+_uuid cidr external_ids options
+----- ---- ------------ -------
+
+DHCP_Relay table
+_uuid external_ids name options servers
+----- ------------ ---- ------- -------
+
+DNS table
+_uuid external_ids options records
+----- ------------ ------- -------
+
+Forwarding_Group table
+_uuid child_port external_ids liveness name vip vmac
+----- ---------- ------------ -------- ---- --- ----
+
+Gateway_Chassis table
+_uuid chassis_name external_ids name options priority
+----- ------------ ------------ ---- ------- --------
+
+HA_Chassis table
+_uuid chassis_name external_ids priority
+----- ------------ ------------ --------
+
+HA_Chassis_Group table
+_uuid external_ids ha_chassis name
+----- ------------ ---------- ----
+
+Load_Balancer table
+_uuid external_ids health_check ip_port_mappings name options protocol selection_fields vips
+----- ------------ ------------ ---------------- ---- ------- -------- ---------------- ----
+
+Load_Balancer_Group table
+_uuid load_balancer name
+----- ------------- ----
+
+Load_Balancer_Health_Check table
+_uuid external_ids options vip
+----- ------------ ------- ---
+
+Logical_Router table
+_uuid copp enabled external_ids load_balancer load_balancer_group name nat options policies ports static_routes
+----- ---- ------- ------------ ------------- ------------------- ---- --- ------- -------- ----- -------------
+
+Logical_Router_Policy table
+_uuid action bfd_sessions chain external_ids jump_chain match nexthop nexthops options output_port priority
+----- ------ ------------ ----- ------------ ---------- ----- ------- -------- ------- ----------- --------
+
+Logical_Router_Port table
+_uuid dhcp_relay enabled external_ids gateway_chassis ha_chassis_group ipv6_prefix ipv6_ra_configs mac name networks options peer status
+----- ---------- ------- ------------ --------------- ---------------- ----------- --------------- --- ---- -------- ------- ---- ------
+
+Logical_Router_Static_Route table
+_uuid bfd external_ids ip_prefix nexthop options output_port policy route_table selection_fields
+----- --- ------------ --------- ------- ------- ----------- ------ ----------- ----------------
+
+Logical_Switch table
+_uuid acls copp dns_records external_ids forwarding_groups load_balancer load_balancer_group name other_config ports qos_rules
+----- ---- ---- ----------- ------------ ----------------- ------------- ------------------- ---- ------------ ----- ---------
+
+Logical_Switch_Port table
+_uuid addresses dhcpv4_options dhcpv6_options dynamic_addresses enabled external_ids ha_chassis_group health_checks mirror_rules name options parent_name peer port_security tag tag_request type up
+----- --------- -------------- -------------- ----------------- ------- ------------ ---------------- ------------- ------------ ---- ------- ----------- ---- ------------- --- ----------- ---- --
+
+Logical_Switch_Port_Health_Check table
+_uuid address options port protocol src_ip status
+----- ------- ------- ---- -------- ------ ------
+
+Meter table
+_uuid bands external_ids fair name unit
+----- ----- ------------ ---- ---- ----
+
+Meter_Band table
+_uuid action burst_size external_ids rate
+----- ------ ---------- ------------ ----
+
+Mirror table
+_uuid external_ids filter index mirror_rules name sink type
+----- ------------ ------ ----- ------------ ---- ---- ----
+
+Mirror_Rule table
+_uuid action match priority
+----- ------ ----- --------
+
+NAT table
+_uuid allowed_ext_ips exempted_ext_ips external_ids external_ip external_mac external_port_range gateway_port logical_ip logical_port match options priority type
+----- --------------- ---------------- ------------ ----------- ------------ ------------------- ------------ ---------- ------------ ----- ------- -------- ----
+
+NB_Global table
+_uuid                                connections                                                                  external_ids hv_cfg hv_cfg_timestamp ipsec name nb_cfg nb_cfg_timestamp options sb_cfg sb_cfg_timestamp ssl
+------------------------------------ ---------------------------------------------------------------------------- ------------ ------ ---------------- ----- ---- ------ ---------------- ------- ------ ---------------- ------------------------------------
+Guid_0000000000000000000000000000003 [Guid_0000000000000000000000000000002, Guid_0000000000000000000000000000001] {}           0      0                false ""   0      0                {}      0      0                Guid_0000000000000000000000000000004
+
+Network_Function table
+_uuid external_ids health_check id inport name outport
+----- ------------ ------------ -- ------ ---- -------
+
+Network_Function_Group table
+_uuid external_ids fallback id mode name network_function network_function_active
+----- ------------ -------- -- ---- ---- ---------------- -----------------------
+
+Network_Function_Health_Check table
+_uuid external_ids name options
+----- ------------ ---- -------
+
+Port_Group table
+_uuid acls external_ids name ports
+----- ---- ------------ ---- -----
+
+QoS table
+_uuid action bandwidth direction external_ids match priority
+----- ------ --------- --------- ------------ ----- --------
+
+SSL table
+_uuid                                bootstrap_ca_cert ca_cert                                                                                                                                  certificate                                                                                                                            external_ids private_key                                                                                                                                   ssl_ciphers ssl_ciphersuites ssl_protocols
+------------------------------------ ----------------- ---------------------------------------------------------------------------------------------------------------------------------------- -------------------------------------------------------------------------------------------------------------------------------------- ------------ --------------------------------------------------------------------------------------------------------------------------------------------- ----------- ---------------- -----------------
+Guid_0000000000000000000000000000004 false             "{OvsTestDirectory________________________}/etc/openvswitch/cacert_SHA256_000000000000000000000000000000000000000000000000000000001.pem" "{OvsTestDirectory________________________}/etc/openvswitch/cert_SHA256_000000000000000000000000000000000000000000000000000000002.pem" {}           "{OvsTestDirectory________________________}/etc/openvswitch/private/key_SHA256_000000000000000000000000000000000000000000000000000000003.pem" ""          ""               "TLSv1.3,TLSv1.2"
+
+Sample table
+_uuid collectors metadata
+----- ---------- --------
+
+Sample_Collector table
+_uuid external_ids id name probability set_id
+----- ------------ -- ---- ----------- ------
+
+Sampling_App table
+_uuid external_ids id type
+----- ------------ -- ----
+
+Static_MAC_Binding table
+_uuid ip logical_port mac override_dynamic_mac
+----- -- ------------ --- --------------------

--- a/test/OVN.Core.IntegrationTests/ClusterPlanNorthboundConnectionRealizerTests.ApplyClusterPlan_UpdatedPlan_IsSuccessful.verified.txt
+++ b/test/OVN.Core.IntegrationTests/ClusterPlanNorthboundConnectionRealizerTests.ApplyClusterPlan_UpdatedPlan_IsSuccessful.verified.txt
@@ -1,0 +1,159 @@
+﻿ACL table
+_uuid action direction external_ids label log match meter name network_function_group options priority sample_est sample_new severity tier
+----- ------ --------- ------------ ----- --- ----- ----- ---- ---------------------- ------- -------- ---------- ---------- -------- ----
+
+Address_Set table
+_uuid addresses external_ids name
+----- --------- ------------ ----
+
+BFD table
+_uuid detect_mult dst_ip external_ids logical_port min_rx min_tx options status
+----- ----------- ------ ------------ ------------ ------ ------ ------- ------
+
+Chassis_Template_Var table
+_uuid chassis external_ids variables
+----- ------- ------------ ---------
+
+Connection table
+_uuid                                external_ids inactivity_probe is_connected max_backoff other_config status                                                                target
+------------------------------------ ------------ ---------------- ------------ ----------- ------------ --------------------------------------------------------------------- ----------------------
+Guid_0000000000000000000000000000001 {}           []               false        []          {}           {bound_port="51641", sec_since_connect="0", sec_since_disconnect="0"} "ptcp:51641:127.0.0.1"
+Guid_0000000000000000000000000000002 {}           []               false        []          {}           {bound_port="51642", sec_since_connect="0", sec_since_disconnect="0"} "pssl:51642:127.0.0.1"
+
+Copp table
+_uuid external_ids meters name
+----- ------------ ------ ----
+
+DHCP_Options table
+_uuid cidr external_ids options
+----- ---- ------------ -------
+
+DHCP_Relay table
+_uuid external_ids name options servers
+----- ------------ ---- ------- -------
+
+DNS table
+_uuid external_ids options records
+----- ------------ ------- -------
+
+Forwarding_Group table
+_uuid child_port external_ids liveness name vip vmac
+----- ---------- ------------ -------- ---- --- ----
+
+Gateway_Chassis table
+_uuid chassis_name external_ids name options priority
+----- ------------ ------------ ---- ------- --------
+
+HA_Chassis table
+_uuid chassis_name external_ids priority
+----- ------------ ------------ --------
+
+HA_Chassis_Group table
+_uuid external_ids ha_chassis name
+----- ------------ ---------- ----
+
+Load_Balancer table
+_uuid external_ids health_check ip_port_mappings name options protocol selection_fields vips
+----- ------------ ------------ ---------------- ---- ------- -------- ---------------- ----
+
+Load_Balancer_Group table
+_uuid load_balancer name
+----- ------------- ----
+
+Load_Balancer_Health_Check table
+_uuid external_ids options vip
+----- ------------ ------- ---
+
+Logical_Router table
+_uuid copp enabled external_ids load_balancer load_balancer_group name nat options policies ports static_routes
+----- ---- ------- ------------ ------------- ------------------- ---- --- ------- -------- ----- -------------
+
+Logical_Router_Policy table
+_uuid action bfd_sessions chain external_ids jump_chain match nexthop nexthops options output_port priority
+----- ------ ------------ ----- ------------ ---------- ----- ------- -------- ------- ----------- --------
+
+Logical_Router_Port table
+_uuid dhcp_relay enabled external_ids gateway_chassis ha_chassis_group ipv6_prefix ipv6_ra_configs mac name networks options peer status
+----- ---------- ------- ------------ --------------- ---------------- ----------- --------------- --- ---- -------- ------- ---- ------
+
+Logical_Router_Static_Route table
+_uuid bfd external_ids ip_prefix nexthop options output_port policy route_table selection_fields
+----- --- ------------ --------- ------- ------- ----------- ------ ----------- ----------------
+
+Logical_Switch table
+_uuid acls copp dns_records external_ids forwarding_groups load_balancer load_balancer_group name other_config ports qos_rules
+----- ---- ---- ----------- ------------ ----------------- ------------- ------------------- ---- ------------ ----- ---------
+
+Logical_Switch_Port table
+_uuid addresses dhcpv4_options dhcpv6_options dynamic_addresses enabled external_ids ha_chassis_group health_checks mirror_rules name options parent_name peer port_security tag tag_request type up
+----- --------- -------------- -------------- ----------------- ------- ------------ ---------------- ------------- ------------ ---- ------- ----------- ---- ------------- --- ----------- ---- --
+
+Logical_Switch_Port_Health_Check table
+_uuid address options port protocol src_ip status
+----- ------- ------- ---- -------- ------ ------
+
+Meter table
+_uuid bands external_ids fair name unit
+----- ----- ------------ ---- ---- ----
+
+Meter_Band table
+_uuid action burst_size external_ids rate
+----- ------ ---------- ------------ ----
+
+Mirror table
+_uuid external_ids filter index mirror_rules name sink type
+----- ------------ ------ ----- ------------ ---- ---- ----
+
+Mirror_Rule table
+_uuid action match priority
+----- ------ ----- --------
+
+NAT table
+_uuid allowed_ext_ips exempted_ext_ips external_ids external_ip external_mac external_port_range gateway_port logical_ip logical_port match options priority type
+----- --------------- ---------------- ------------ ----------- ------------ ------------------- ------------ ---------- ------------ ----- ------- -------- ----
+
+NB_Global table
+_uuid                                connections                                                                  external_ids hv_cfg hv_cfg_timestamp ipsec name nb_cfg nb_cfg_timestamp options sb_cfg sb_cfg_timestamp ssl
+------------------------------------ ---------------------------------------------------------------------------- ------------ ------ ---------------- ----- ---- ------ ---------------- ------- ------ ---------------- ------------------------------------
+Guid_0000000000000000000000000000003 [Guid_0000000000000000000000000000002, Guid_0000000000000000000000000000001] {}           0      0                false ""   0      0                {}      0      0                Guid_0000000000000000000000000000004
+
+Network_Function table
+_uuid external_ids health_check id inport name outport
+----- ------------ ------------ -- ------ ---- -------
+
+Network_Function_Group table
+_uuid external_ids fallback id mode name network_function network_function_active
+----- ------------ -------- -- ---- ---- ---------------- -----------------------
+
+Network_Function_Health_Check table
+_uuid external_ids name options
+----- ------------ ---- -------
+
+Port_Group table
+_uuid acls external_ids name ports
+----- ---- ------------ ---- -----
+
+QoS table
+_uuid action bandwidth direction external_ids match priority
+----- ------ --------- --------- ------------ ----- --------
+
+SSL table
+_uuid                                bootstrap_ca_cert ca_cert                                                                                                                                  certificate                                                                                                                            external_ids private_key                                                                                                                                   ssl_ciphers ssl_ciphersuites ssl_protocols
+------------------------------------ ----------------- ---------------------------------------------------------------------------------------------------------------------------------------- -------------------------------------------------------------------------------------------------------------------------------------- ------------ --------------------------------------------------------------------------------------------------------------------------------------------- ----------- ---------------- -----------------
+Guid_0000000000000000000000000000004 false             "{OvsTestDirectory________________________}/etc/openvswitch/cacert_SHA256_000000000000000000000000000000000000000000000000000000001.pem" "{OvsTestDirectory________________________}/etc/openvswitch/cert_SHA256_000000000000000000000000000000000000000000000000000000002.pem" {}           "{OvsTestDirectory________________________}/etc/openvswitch/private/key_SHA256_000000000000000000000000000000000000000000000000000000003.pem" ""          ""               "TLSv1.3,TLSv1.2"
+
+Sample table
+_uuid collectors metadata
+----- ---------- --------
+
+Sample_Collector table
+_uuid external_ids id name probability set_id
+----- ------------ -- ---- ----------- ------
+
+Sampling_App table
+_uuid external_ids id type
+----- ------------ -- ----
+
+Static_MAC_Binding table
+_uuid ip logical_port mac override_dynamic_mac
+----- -- ------------ --- --------------------

--- a/test/OVN.Core.IntegrationTests/ClusterPlanNorthboundConnectionRealizerTests.cs
+++ b/test/OVN.Core.IntegrationTests/ClusterPlanNorthboundConnectionRealizerTests.cs
@@ -1,0 +1,129 @@
+using System.Net;
+using AwesomeAssertions;
+using Dbosoft.OVN.Model.OVN;
+using Dbosoft.OVN.OSCommands.OVN;
+using Dbosoft.OVN.SimplePki;
+using Xunit.Abstractions;
+
+using static Dbosoft.OVN.Core.IntegrationTests.HashHelper;
+
+namespace Dbosoft.OVN.Core.IntegrationTests;
+
+public class ClusterPlanNorthboundConnectionRealizerTests : OvnNorthboundRemoteControlToolTestBase
+{
+    private readonly IPkiService _pkiService;
+    private readonly OvsFile _clientPrivateKey = new("/etc/dotnet-ovn/test-client", "key.pem");
+    private readonly OvsFile _clientCertificate = new("/etc/dotnet-ovn/test-client", "cert.pem");
+    private readonly OvsFile _clientCaCertificate = new("/etc/dotnet-ovn/test-client", "ca-cert.pem");
+
+    public ClusterPlanNorthboundConnectionRealizerTests(ITestOutputHelper testOutputHelper)
+        : base(testOutputHelper)
+    {
+        _pkiService = new PkiService(SystemEnvironment);
+    }
+
+    public override async Task InitializeAsync()
+    {
+        await base.InitializeAsync();
+        await _pkiService.InitializeAsync();
+
+        var clientPki = await _pkiService.GenerateChassisPkiAsync("test-client");
+
+        SystemEnvironment.FileSystem.EnsurePathForFileExists(_clientPrivateKey);
+        await SystemEnvironment.FileSystem.WriteFileAsync(_clientPrivateKey, clientPki.PrivateKey);
+        SystemEnvironment.FileSystem.EnsurePathForFileExists(_clientCertificate);
+        await SystemEnvironment.FileSystem.WriteFileAsync(_clientCertificate, clientPki.Certificate);
+        SystemEnvironment.FileSystem.EnsurePathForFileExists(_clientCaCertificate);
+        await SystemEnvironment.FileSystem.WriteFileAsync(_clientCaCertificate, clientPki.CaCertificate);
+    }
+
+    [Fact]
+    public async Task ApplyClusterPlan_NewPlan_IsSuccessful()
+    {
+        var initialChassisPki = await _pkiService.GenerateChassisPkiAsync("test-chassis");
+        await ApplyClusterPlan(CreateClusterPlan(initialChassisPki));
+
+        await VerifyDatabase();
+
+        var configDirectory = GetDataDirectoryInfo().Should().ContainDirectory("etc")
+            .Which.Should().ContainDirectory("openvswitch")
+            .Subject;
+        configDirectory.Should().ContainFile($"cacert_{ComputeSha256(initialChassisPki.CaCertificate)}.pem");
+        configDirectory.Should().ContainFile($"cert_{ComputeSha256(initialChassisPki.Certificate)}.pem");
+        configDirectory.Should().ContainDirectory("private")
+            .Which.Should().ContainFile($"key_{ComputeSha256(initialChassisPki.PrivateKey)}.pem");
+
+        await TestConnection(41641, false);
+        await TestConnection(41642, true);
+    }
+
+    [Fact]
+    public async Task ApplyClusterPlan_UpdatedPlan_IsSuccessful()
+    {
+        var initialChassisPki = await _pkiService.GenerateChassisPkiAsync("test-chassis");
+        await ApplyClusterPlan(CreateClusterPlan(initialChassisPki));
+
+        var updatedChassisPki = await _pkiService.GenerateChassisPkiAsync("test-chassis");
+        var updatedPlan = new ClusterPlan()
+            .SetNorthboundSsl(updatedChassisPki.PrivateKey, updatedChassisPki.Certificate, updatedChassisPki.CaCertificate)
+            .AddNorthboundConnection(51641, false, IPAddress.Parse("127.0.0.1"))
+            .AddNorthboundConnection(51642, true, IPAddress.Parse("127.0.0.1"));
+
+        await ApplyClusterPlan(updatedPlan);
+
+        await VerifyDatabase();
+
+        var configDirectory = GetDataDirectoryInfo().Should().ContainDirectory("etc")
+            .Which.Should().ContainDirectory("openvswitch")
+            .Subject;
+        // The CA certificate does not change as we use the same PKI
+        configDirectory.Should().ContainFile($"cacert_{ComputeSha256(initialChassisPki.CaCertificate)}.pem");
+        configDirectory.Should().ContainFile($"cert_{ComputeSha256(updatedChassisPki.Certificate)}.pem");
+        configDirectory.Should().NotContainFile($"cert_{ComputeSha256(initialChassisPki.Certificate)}.pem");
+        var privateConfigDirectory = configDirectory.Should().ContainDirectory("private").Subject;
+        privateConfigDirectory.Should().ContainFile($"key_{ComputeSha256(updatedChassisPki.PrivateKey)}.pem");
+        privateConfigDirectory.Should().NotContainFile($"key_{ComputeSha256(initialChassisPki.PrivateKey)}.pem");
+
+        await TestConnection(51641, false);
+        await TestConnection(51642, true);
+    }
+
+    private async Task ApplyClusterPlan(ClusterPlan clusterPlan)
+    {
+        var realizer = new ClusterPlanNorthboundRealizer(SystemEnvironment, ControlTool);
+
+        var either = await realizer.ApplyClusterPlan(clusterPlan);
+        either.ThrowIfLeft();
+
+        // The ovsdb-server writes status information for the connections
+        // into the connection table. We just wait a bit here to ensure that
+        // the status information has been written. Otherwise, the tests can
+        // randomly fail depending on whether the status information is present
+        // or not in the database and hence included in the database snapshot.
+        await Task.Delay(2000);
+    }
+
+    private ClusterPlan CreateClusterPlan(OvsPkiConfig ovsPki) =>
+        new ClusterPlan()
+            .SetNorthboundSsl(ovsPki.PrivateKey, ovsPki.Certificate, ovsPki.CaCertificate)
+            .AddNorthboundConnection(41641, false, IPAddress.Parse("127.0.0.1"))
+            .AddNorthboundConnection(41642, true, IPAddress.Parse("127.0.0.1"));
+
+    private OVNControlTool CreateControlTool(int port, bool ssl)
+    {
+        OvsDbConnection dbConnection = ssl
+            ? new OvsDbConnection("127.0.0.1", port, _clientPrivateKey, _clientCertificate, _clientCaCertificate)
+            : new OvsDbConnection("127.0.0.1", port);
+
+        return new OVNControlTool(SystemEnvironment, dbConnection);
+    }
+
+    private async Task TestConnection(int port, bool ssl)
+    {
+        var controlTool = CreateControlTool(port, ssl);
+        var globalEither = await controlTool.FindRecords<NorthboundGlobal>(
+            OVNTableNames.Global);
+        var globalRecords = globalEither.ThrowIfLeft();
+        globalRecords.Should().HaveCount(1);
+    }
+}

--- a/test/OVN.Core.IntegrationTests/OvnNorthboundRemoteControlToolTestBase.cs
+++ b/test/OVN.Core.IntegrationTests/OvnNorthboundRemoteControlToolTestBase.cs
@@ -1,0 +1,38 @@
+using Dbosoft.OVN.OSCommands.OVN;
+using Dbosoft.OVN.OSCommands.OVS;
+using LanguageExt;
+using LanguageExt.Common;
+using Xunit.Abstractions;
+
+namespace Dbosoft.OVN.Core.IntegrationTests;
+
+/// <summary>
+/// Northbound test base which starts the northbound database with the
+/// remote listener and SSL configuration read from the database (like the
+/// southbound database). This allows testing remote and SSL connections to
+/// the northbound database.
+/// </summary>
+public abstract class OvnNorthboundRemoteControlToolTestBase : OvsDbTestBase
+{
+    private static readonly OVSDbSettings DbSettings = OVSDbSettingsBuilder
+        .ForNorthbound()
+        .UseRemoteConfigsFromDatabase(true)
+        .Build();
+
+    protected readonly OVNControlTool ControlTool;
+
+    protected OvnNorthboundRemoteControlToolTestBase(
+        ITestOutputHelper testOutputHelper)
+        : base(testOutputHelper, DbSettings)
+    {
+        ControlTool = new OVNControlTool(SystemEnvironment, DbSettings.Connection);
+    }
+
+    protected override EitherAsync<Error, Unit> InitializeDatabase() =>
+        ControlTool.InitDb();
+
+    protected async Task VerifyDatabase()
+    {
+        await VerifyDatabase("OVN_Northbound", "7.18.0");
+    }
+}

--- a/test/OVN.Primitives.Tests/PlannedSslColumnsTest.cs
+++ b/test/OVN.Primitives.Tests/PlannedSslColumnsTest.cs
@@ -1,0 +1,38 @@
+using Dbosoft.OVN.Model.OVN;
+
+namespace Dbosoft.OVN.Primitives.Tests;
+
+public class PlannedSslColumnsTest
+{
+    // The planned SSL Columns extend the base PlannedOvsSsl metadata (which
+    // already declares private_key/certificate/ca_cert) with the OVN-specific
+    // ssl_* columns. Accessing the static field must not throw (a duplicate key
+    // in the initializer would fail static initialization) and must expose both
+    // the base and the ssl_* columns.
+
+    [Fact]
+    public void PlannedNorthboundSsl_Columns_contain_base_and_ssl_columns()
+    {
+        var columns = PlannedNorthboundSsl.Columns;
+
+        Assert.Contains("private_key", columns.Keys);
+        Assert.Contains("certificate", columns.Keys);
+        Assert.Contains("ca_cert", columns.Keys);
+        Assert.Contains("ssl_protocols", columns.Keys);
+        Assert.Contains("ssl_ciphers", columns.Keys);
+        Assert.Contains("ssl_ciphersuites", columns.Keys);
+    }
+
+    [Fact]
+    public void PlannedSouthboundSsl_Columns_contain_base_and_ssl_columns()
+    {
+        var columns = PlannedSouthboundSsl.Columns;
+
+        Assert.Contains("private_key", columns.Keys);
+        Assert.Contains("certificate", columns.Keys);
+        Assert.Contains("ca_cert", columns.Keys);
+        Assert.Contains("ssl_protocols", columns.Keys);
+        Assert.Contains("ssl_ciphers", columns.Keys);
+        Assert.Contains("ssl_ciphersuites", columns.Keys);
+    }
+}

--- a/test/OVNAgent.Tests/ClusterPlanParserTests.cs
+++ b/test/OVNAgent.Tests/ClusterPlanParserTests.cs
@@ -13,6 +13,15 @@ public class ClusterPlanParserTests
                               chassis:
                               - name: test-chassis-1
                                 priority: 10
+                            northbound_endpoints:
+                            - port: 6641
+                            - port: 16641
+                              ssl: true
+                              ip_address: 203.0.113.1
+                            northbound_ssl:
+                              private_key: test-nb-private-key
+                              certificate: test-nb-certificate
+                              ca_certificate: test-nb-ca-certificate
                             southbound_endpoints:
                             - port: 42421
                             - port: 42422
@@ -38,6 +47,19 @@ public class ClusterPlanParserTests
         plannedChassis.Name.Should().Be("test-chassis-1");
         plannedChassis.ChassisGroupName.Should().Be("test-cluster");
         plannedChassis.Priority.Should().Be(10);
+
+        plan.PlannedNorthboundConnections.Should().HaveCount(2);
+        plan.PlannedNorthboundConnections.ToDictionary()
+            .Should().ContainKey("ptcp:6641")
+            .WhoseValue.Target.Should().Be("ptcp:6641");
+        plan.PlannedNorthboundConnections.ToDictionary()
+            .Should().ContainKey("pssl:16641:203.0.113.1")
+            .WhoseValue.Target.Should().Be("pssl:16641:203.0.113.1");
+
+        plan.PlannedNorthboundSsl.Should().NotBeNull();
+        plan.PlannedNorthboundSsl.PrivateKey.Should().Be("test-nb-private-key");
+        plan.PlannedNorthboundSsl.Certificate.Should().Be("test-nb-certificate");
+        plan.PlannedNorthboundSsl.CaCertificate.Should().Be("test-nb-ca-certificate");
 
         plan.PlannedSouthboundConnections.Should().HaveCount(2);
         plan.PlannedSouthboundConnections.ToDictionary()


### PR DESCRIPTION
The cluster plan previously could expose only the **southbound** database to remote clients over SSL. The northbound database was reachable through the local pipe only, so a separate controller process could not connect to a remote northbound DB.

## What changed
- New northbound model types mirroring the southbound ones: `NorthboundGlobal`, `NorthboundConnection`, `NorthboundSsl` and their planned variants, plus `OVNTableNames.Connection`/`Ssl`.
- New plan extensions `AddNorthboundConnection` / `SetNorthboundSsl`, applied in `ClusterPlanNorthboundRealizer` (connections + SSL) reusing the generic `PlanRealizer.ApplySsl`.
- `NetworkControllerNode` now starts the northbound DB with `UseRemoteConfigsFromDatabase(true)` (like the southbound node), so the NB_Global `connections`/`ssl` tables drive the remote listeners. With no planned connections this only adds the local pipe remote, so in-process deployments are unaffected.
- `OVNAgent` cluster-plan YAML gains `northbound_endpoints` / `northbound_ssl`.

## Tests
- Extended `ClusterPlanParserTests` for the new northbound YAML.
- New `ClusterPlanNorthboundConnectionRealizerTests` (mirroring the southbound test) verifying the realized DB and live `ptcp`/`pssl` connections to the northbound DB. Full integration + unit suites pass.