### PR TITLE
Honour adminOnly when ensuring an OvsFile's directory

### DIFF
--- a/src/OVN.Core/DefaultFileSystem.cs
+++ b/src/OVN.Core/DefaultFileSystem.cs
@@ -74,7 +74,7 @@ public class DefaultFileSystem : IFileSystem
     public void EnsurePathForFileExists(OvsFile file, bool adminOnly = false)
     {
         var path = ResolveOvsFilePath(file);
-        EnsurePathForFileExists(path);
+        EnsurePathForFileExists(path, adminOnly);
     }
 
     public void DeleteFile(string path)


### PR DESCRIPTION
`EnsurePathForFileExists(OvsFile, adminOnly)` discarded the `adminOnly` flag — it called the path overload without it — so SSL private-key directories created via an `OvsFile` (e.g. `/etc/openvswitch/private` and component client-key directories) were never owner-restricted. Pass the flag through so `adminOnly: true` is honoured.

Found during a security review of the eryph northbound-SSL work (the fix originally went onto the already-merged #61 branch by mistake; this re-targets it at main).